### PR TITLE
feat(workers): add wake channel for reduced pickup latency

### DIFF
--- a/infrastructure/events/wake.go
+++ b/infrastructure/events/wake.go
@@ -1,0 +1,29 @@
+package events
+
+import "context"
+
+// WakeChannel returns a buffered channel that receives a value every time
+// the bus emits an event matching topic. Designed to feed
+// workers.WithWakeChannel.
+//
+// Sends are coalesced — bursts collapse into a single wake — and never block
+// the bus subscriber. Lost wakes are tolerated; the consumer (typically a
+// polling worker pool) will catch up on its next interval tick.
+//
+// The returned Subscription's lifetime is the caller's to manage. Calling
+// Unsubscribe stops further wakes from firing. Closing the bus has the same
+// effect for all subscriptions it owns.
+func WakeChannel(bus Bus, topic string) (<-chan struct{}, Subscription, error) {
+	wake := make(chan struct{}, 1)
+	sub, err := bus.Subscribe(topic, func(_ context.Context, _ Event) error {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return wake, sub, nil
+}

--- a/infrastructure/events/wake_test.go
+++ b/infrastructure/events/wake_test.go
@@ -1,0 +1,130 @@
+package events_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/gopernicus/gopernicus/infrastructure/events"
+	"github.com/gopernicus/gopernicus/infrastructure/events/memorybus"
+)
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(discard{}, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+type testEvent struct {
+	events.BaseEvent
+}
+
+func TestWakeChannel_EmitFiresWake(t *testing.T) {
+	bus := memorybus.New(silentLogger())
+	defer bus.Close(context.Background())
+
+	wake, sub, err := events.WakeChannel(bus, "test.event")
+	if err != nil {
+		t.Fatalf("WakeChannel: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	bus.Emit(context.Background(), testEvent{BaseEvent: events.NewBaseEvent("test.event")}, events.WithSync())
+
+	select {
+	case <-wake:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected wake within 100ms")
+	}
+}
+
+func TestWakeChannel_BurstIsCoalesced(t *testing.T) {
+	bus := memorybus.New(silentLogger())
+	defer bus.Close(context.Background())
+
+	wake, sub, err := events.WakeChannel(bus, "test.event")
+	if err != nil {
+		t.Fatalf("WakeChannel: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	for i := 0; i < 100; i++ {
+		bus.Emit(context.Background(), testEvent{BaseEvent: events.NewBaseEvent("test.event")}, events.WithSync())
+	}
+
+	received := 0
+	timeout := time.After(100 * time.Millisecond)
+drain:
+	for {
+		select {
+		case <-wake:
+			received++
+		case <-timeout:
+			break drain
+		}
+	}
+
+	if received == 0 {
+		t.Error("expected at least one wake")
+	}
+	if received > 10 {
+		t.Errorf("expected coalescing to limit receives, got %d", received)
+	}
+}
+
+func TestWakeChannel_NonMatchingTopicIgnored(t *testing.T) {
+	bus := memorybus.New(silentLogger())
+	defer bus.Close(context.Background())
+
+	wake, sub, err := events.WakeChannel(bus, "a.foo")
+	if err != nil {
+		t.Fatalf("WakeChannel: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	bus.Emit(context.Background(), testEvent{BaseEvent: events.NewBaseEvent("b.bar")}, events.WithSync())
+
+	select {
+	case <-wake:
+		t.Fatal("unexpected wake for non-matching topic")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestWakeChannel_UnsubscribeStopsWakes(t *testing.T) {
+	bus := memorybus.New(silentLogger())
+	defer bus.Close(context.Background())
+
+	wake, sub, err := events.WakeChannel(bus, "test.event")
+	if err != nil {
+		t.Fatalf("WakeChannel: %v", err)
+	}
+
+	sub.Unsubscribe()
+
+	bus.Emit(context.Background(), testEvent{BaseEvent: events.NewBaseEvent("test.event")}, events.WithSync())
+
+	select {
+	case <-wake:
+		t.Fatal("unexpected wake after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestWakeChannel_BusCloseIsSafe(t *testing.T) {
+	bus := memorybus.New(silentLogger())
+
+	_, sub, err := events.WakeChannel(bus, "test.event")
+	if err != nil {
+		t.Fatalf("WakeChannel: %v", err)
+	}
+
+	bus.Close(context.Background())
+
+	if err := sub.Unsubscribe(); err != nil {
+		t.Errorf("Unsubscribe after close should be safe, got: %v", err)
+	}
+}

--- a/sdk/workers/pool.go
+++ b/sdk/workers/pool.go
@@ -28,6 +28,7 @@ type poolConfig struct {
 	idleInterval time.Duration
 	middlewares  []Middleware
 	logger       *slog.Logger
+	wake         <-chan struct{}
 }
 
 // WithName sets the worker pool name.
@@ -60,6 +61,29 @@ func WithLogger(logger *slog.Logger) PoolOption {
 	return func(c *poolConfig) { c.logger = logger }
 }
 
+// WithWakeChannel registers a signal channel that the pool selects on
+// alongside its interval timer. When a value is received, the next work
+// iteration runs immediately.
+//
+// The channel is a non-durable hint: the pool drains receives opportunistically
+// and never blocks the sender. Callers should use a buffered channel (cap 1)
+// with non-blocking sends:
+//
+//	wake := make(chan struct{}, 1)
+//	select { case wake <- struct{}{}: default: }
+//
+// Lost wake signals are tolerated — the polling backstop catches the work
+// on its next idle/active tick. If wake is nil, the pool behaves exactly
+// as if no option were passed.
+//
+// Do not close the wake channel — receiving on a closed channel returns
+// immediately and would spin work iterations until ctx cancel. The intended
+// lifecycle is: pool runs until ctx cancels; emitters tear themselves down
+// without closing wake.
+func WithWakeChannel(wake <-chan struct{}) PoolOption {
+	return func(c *poolConfig) { c.wake = wake }
+}
+
 // WorkerPool manages N worker goroutines that call a WorkFunc in a polling loop.
 // The pool handles adaptive polling, panic recovery, and graceful shutdown.
 // It knows nothing about jobs or tasks — that's the Runner's concern.
@@ -70,6 +94,7 @@ type WorkerPool struct {
 	pollInterval time.Duration
 	idleInterval time.Duration
 	log          *slog.Logger
+	wake         <-chan struct{}
 
 	workFunc    WorkFunc // Final middleware-wrapped work function
 	middlewares []Middleware
@@ -118,6 +143,7 @@ func NewPool(workFunc WorkFunc, cfg Options, opts ...PoolOption) *WorkerPool {
 		pollInterval: c.pollInterval,
 		idleInterval: c.idleInterval,
 		log:          c.logger,
+		wake:         c.wake,
 		middlewares:  c.middlewares,
 		errors:       make(chan error, c.workerCount),
 	}
@@ -227,61 +253,62 @@ func (wp *WorkerPool) worker(workerID string) {
 		select {
 		case <-wp.ctx.Done():
 			return
-
 		case <-ticker.C:
-			ctx := WithWorkerID(wp.ctx, workerID)
-			err := wp.workWithPanicRecovery(ctx)
+		case <-wp.wake:
+		}
 
-			wp.stats.iterations.Add(1)
-			if err != nil && !errors.Is(err, ErrNoWork) {
-				wp.stats.errors.Add(1)
+		ctx := WithWorkerID(wp.ctx, workerID)
+		err := wp.workWithPanicRecovery(ctx)
+
+		wp.stats.iterations.Add(1)
+		if err != nil && !errors.Is(err, ErrNoWork) {
+			wp.stats.errors.Add(1)
+		}
+
+		var newInterval time.Duration
+
+		if err != nil {
+			if errors.Is(err, ErrWorkerShutdown) {
+				wp.log.InfoContext(ctx, "worker shutting down as requested",
+					"worker_id", workerID)
+				return
 			}
 
-			var newInterval time.Duration
-
-			if err != nil {
-				if errors.Is(err, ErrWorkerShutdown) {
-					wp.log.InfoContext(ctx, "worker shutting down as requested",
+			if errors.Is(err, ErrPoolShutdown) {
+				wp.log.ErrorContext(ctx, "worker requesting pool shutdown",
+					"worker_id", workerID,
+					"error", err)
+				select {
+				case wp.errors <- fmt.Errorf("worker %s: %w", workerID, err):
+				default:
+					wp.log.ErrorContext(ctx, "error channel full",
 						"worker_id", workerID)
-					return
 				}
+				return
+			}
 
-				if errors.Is(err, ErrPoolShutdown) {
-					wp.log.ErrorContext(ctx, "worker requesting pool shutdown",
+			if errors.Is(err, ErrNoWork) {
+				newInterval = wp.idleInterval
+				if currentInterval != wp.idleInterval {
+					wp.log.InfoContext(ctx, "no work available, switching to idle",
 						"worker_id", workerID,
-						"error", err)
-					select {
-					case wp.errors <- fmt.Errorf("worker %s: %w", workerID, err):
-					default:
-						wp.log.ErrorContext(ctx, "error channel full",
-							"worker_id", workerID)
-					}
-					return
-				}
-
-				if errors.Is(err, ErrNoWork) {
-					newInterval = wp.idleInterval
-					if currentInterval != wp.idleInterval {
-						wp.log.InfoContext(ctx, "no work available, switching to idle",
-							"worker_id", workerID,
-							"idle_interval", wp.idleInterval)
-					}
-				} else {
-					newInterval = wp.pollInterval
+						"idle_interval", wp.idleInterval)
 				}
 			} else {
 				newInterval = wp.pollInterval
-				if currentInterval != wp.pollInterval {
-					wp.log.InfoContext(ctx, "work completed, switching to active",
-						"worker_id", workerID,
-						"poll_interval", wp.pollInterval)
-				}
 			}
+		} else {
+			newInterval = wp.pollInterval
+			if currentInterval != wp.pollInterval {
+				wp.log.InfoContext(ctx, "work completed, switching to active",
+					"worker_id", workerID,
+					"poll_interval", wp.pollInterval)
+			}
+		}
 
-			if newInterval != currentInterval {
-				currentInterval = newInterval
-				ticker.Reset(newInterval)
-			}
+		if newInterval != currentInterval {
+			currentInterval = newInterval
+			ticker.Reset(newInterval)
 		}
 	}
 }

--- a/sdk/workers/pool_test.go
+++ b/sdk/workers/pool_test.go
@@ -404,3 +404,226 @@ func TestPool_Stats(t *testing.T) {
 		t.Errorf("expected 0 active workers after stop, got %d", stats.ActiveWorkers)
 	}
 }
+
+// --- Wake channel tests ---
+
+func TestPool_WakeChannel_TriggersImmediateWork(t *testing.T) {
+	var workFired atomic.Bool
+	workStarted := make(chan struct{})
+
+	work := func(ctx context.Context) error {
+		if !workFired.Load() {
+			workFired.Store(true)
+			close(workStarted)
+		}
+		return ErrNoWork
+	}
+
+	wake := make(chan struct{}, 1)
+
+	opts := Options{
+		Name:         "test",
+		WorkerCount:  1,
+		PollInterval: 5 * time.Second,
+		IdleInterval: 10 * time.Second,
+	}
+	pool := NewPool(work, opts, WithLogger(silentLogger()), WithWakeChannel(wake))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		pool.Start(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	workFired.Store(false)
+
+	wake <- struct{}{}
+
+	select {
+	case <-workStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("wake did not trigger immediate work within 100ms")
+	}
+
+	pool.Stop()
+}
+
+func TestPool_WakeChannel_NilIsSafe(t *testing.T) {
+	var calls atomic.Int64
+
+	work := func(ctx context.Context) error {
+		calls.Add(1)
+		return ErrNoWork
+	}
+
+	pool := NewPool(work, defaultPoolOpts(), WithLogger(silentLogger()), WithWakeChannel(nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		pool.Start(ctx)
+		close(done)
+	}()
+
+	<-done
+
+	if calls.Load() == 0 {
+		t.Error("expected pool to run normally with nil wake channel")
+	}
+}
+
+func TestPool_WakeChannel_CtxDoneTakesPrecedence(t *testing.T) {
+	work := func(ctx context.Context) error {
+		return ErrNoWork
+	}
+
+	wake := make(chan struct{}, 1)
+	pool := NewPool(work, defaultPoolOpts(), WithLogger(silentLogger()), WithWakeChannel(wake))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		pool.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	wake <- struct{}{}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool did not exit after ctx cancel despite wake signal")
+	}
+}
+
+func TestPool_WakeChannel_CoalescedSendsAreSafe(t *testing.T) {
+	var iterations atomic.Int64
+
+	work := func(ctx context.Context) error {
+		iterations.Add(1)
+		return ErrNoWork
+	}
+
+	wake := make(chan struct{}, 1)
+	pool := NewPool(work, defaultPoolOpts(), WithLogger(silentLogger()), WithWakeChannel(wake))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		pool.Start(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	for i := 0; i < 100; i++ {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	pool.Stop()
+
+	if iterations.Load() == 0 {
+		t.Error("expected at least one wake-driven iteration")
+	}
+}
+
+func TestPool_WakeChannel_OneWakePerSignalAcrossWorkers(t *testing.T) {
+	var iterations atomic.Int64
+	started := make(chan struct{})
+	var startedOnce sync.Once
+
+	work := func(ctx context.Context) error {
+		startedOnce.Do(func() { close(started) })
+		iterations.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return ErrNoWork
+	}
+
+	wake := make(chan struct{}, 1)
+
+	opts := Options{
+		Name:         "test",
+		WorkerCount:  3,
+		PollInterval: 5 * time.Second,
+		IdleInterval: 10 * time.Second,
+	}
+	pool := NewPool(work, opts, WithLogger(silentLogger()), WithWakeChannel(wake))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		pool.Start(ctx)
+	}()
+
+	<-started
+	time.Sleep(100 * time.Millisecond)
+
+	before := iterations.Load()
+	wake <- struct{}{}
+	time.Sleep(100 * time.Millisecond)
+	after := iterations.Load()
+
+	pool.Stop()
+
+	wakeTriggered := after - before
+	if wakeTriggered > 1 {
+		t.Errorf("expected at most 1 wake-triggered iteration, got %d", wakeTriggered)
+	}
+}
+
+func TestPool_WakeChannel_WakeWhileIdle_DropsToActive(t *testing.T) {
+	var noWorkCount atomic.Int64
+	var workCount atomic.Int64
+	returnWork := atomic.Bool{}
+
+	work := func(ctx context.Context) error {
+		if returnWork.Load() {
+			workCount.Add(1)
+			return nil
+		}
+		noWorkCount.Add(1)
+		return ErrNoWork
+	}
+
+	wake := make(chan struct{}, 1)
+
+	opts := Options{
+		Name:         "test",
+		WorkerCount:  1,
+		PollInterval: 20 * time.Millisecond,
+		IdleInterval: 5 * time.Second,
+	}
+	pool := NewPool(work, opts, WithLogger(silentLogger()), WithWakeChannel(wake))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		pool.Start(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	returnWork.Store(true)
+	wake <- struct{}{}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if workCount.Load() < 2 {
+		t.Errorf("expected multiple work iterations after wake (active polling), got %d", workCount.Load())
+	}
+
+	pool.Stop()
+}

--- a/workshop/documentation/docs/gopernicus/infrastructure/events.md
+++ b/workshop/documentation/docs/gopernicus/infrastructure/events.md
@@ -349,6 +349,24 @@ Events can implement `EventEncoder` for custom serialization (protobuf, msgpack,
 data, err := events.EncodeEvent(event)
 ```
 
+## WakeChannel
+
+`WakeChannel` bridges a bus topic to a worker pool's wake channel. Every time an event matching the topic is emitted, the returned channel receives a value — suitable for feeding to `workers.WithWakeChannel`.
+
+```go
+wake, sub, err := events.WakeChannel(bus, "job.enqueued")
+if err != nil {
+    return err
+}
+defer sub.Unsubscribe()
+
+pool := workers.NewPool(work, opts,
+    workers.WithWakeChannel(wake),
+)
+```
+
+Sends are coalesced (bursts collapse into one signal) and never block the bus. Lost wakes are tolerated — the pool's polling backstop catches up. See [SDK / Workers](/docs/gopernicus/sdk/workers#reducing-pickup-latency-with-wake-hints) for the full pattern.
+
 ## See also
 
 - [SDK / Async](/docs/gopernicus/sdk/async) — simpler fire-and-forget without pub/sub

--- a/workshop/documentation/docs/gopernicus/sdk/workers.md
+++ b/workshop/documentation/docs/gopernicus/sdk/workers.md
@@ -82,6 +82,49 @@ Workers start at 1ms, then switch behavior based on the work result:
 | `ErrWorkerShutdown` | worker exits |
 | `ErrPoolShutdown` | all workers exit |
 
+### Reducing pickup latency with wake hints
+
+Adaptive polling works well for batch work, but user-triggered jobs (e.g. a Slack bot pulling files into Drive) suffer up to one full `idleInterval` of latency when the pool is idle.
+
+`WithWakeChannel` lets callers push a hint that work just landed. The pool selects on the wake channel alongside its interval timer — a signal triggers an immediate work iteration without giving up the polling backstop that handles retries and crash recovery.
+
+```go
+// Create a wake channel (buffered, cap 1).
+wake := make(chan struct{}, 1)
+
+pool := workers.NewPool(runner.WorkFunc(), opts,
+    workers.WithIdleInterval(5*time.Minute),  // long backstop
+    workers.WithWakeChannel(wake),
+)
+
+// After enqueuing work, send a non-blocking wake signal.
+select {
+case wake <- struct{}{}:
+default: // channel full — pool will pick it up
+}
+```
+
+The wake is a hint, not a contract. Sends are coalesced (bursts collapse into one wake) and never block. If the signal is lost, polling catches up on the next tick.
+
+For event-driven wake signals, use `events.WakeChannel` to bridge a bus topic to the pool:
+
+```go
+import "github.com/gopernicus/gopernicus/infrastructure/events"
+
+wake, sub, err := events.WakeChannel(bus, "drivebot.upload.requested")
+if err != nil {
+    return fmt.Errorf("wake subscribe: %w", err)
+}
+defer sub.Unsubscribe()
+
+pool := workers.NewPool(runner.WorkFunc(), opts,
+    workers.WithIdleInterval(5*time.Minute),
+    workers.WithWakeChannel(wake),
+)
+```
+
+Now every `drivebot.upload.requested` event wakes the pool immediately.
+
 ---
 
 ## Sentinels


### PR DESCRIPTION
## Summary

- Add `WithWakeChannel` option to `WorkerPool` — pool selects on wake channel alongside timer, enabling immediate work pickup when callers signal that jobs were enqueued
- Add `events.WakeChannel` helper to bridge bus topics to wake signals
- Wake is a hint, not a contract — coalesced sends, never blocks, polling backstop still catches missed signals

## Files changed

| Layer | Files |
|-------|-------|
| sdk/workers | pool.go, pool_test.go (+6 tests) |
| infrastructure/events | wake.go, wake_test.go (+5 tests) |
| docs | workers.md, events.md |

## Test plan

- [x] `go test ./sdk/workers/...` — all pass
- [x] `go test ./infrastructure/events/...` — all pass
- [x] Docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)