### PR TITLE
docs(testing): cover @skip-integration-test, testPGXOptions, scope-aw…

### DIFF
--- a/workshop/documentation/docs/cli/generate.md
+++ b/workshop/documentation/docs/cli/generate.md
@@ -78,8 +78,8 @@ triggers generation in the repository, store, bridge, and test layers.
 
 | File | Created | Overwritten | Description |
 |---|---|---|---|
-| `generated_test.go` | Always | Yes | Auto-generated test cases for all store methods. |
-| `store_test.go` | Once | No | Test setup, fixtures, and custom test stubs. |
+| `generated_test.go` | Always (unless opted out) | Yes | Auto-generated `Create` / `Get` / `List` / `Delete` / `SoftDelete` smoke tests. Suppressed by `-- @skip-integration-test` at the top of `queries.sql`; a previously generated file is removed on opt-in. |
+| `store_test.go` | Once | No | `setupTestStore` helper plus `migrateTestDB` and `testPGXOptions` hooks for the test container. |
 
 **Cache** (`core/repositories/<domain>/<entity>/`) -- only when `@cache` annotations are present:
 
@@ -125,7 +125,7 @@ triggers generation in the repository, store, bridge, and test layers.
 
 | File | Created | Overwritten | Description |
 |---|---|---|---|
-| `generated.go` | Always | Yes | Factory functions for creating test entities with resolved FK relationships. |
+| `generated.go` | Always | Yes | Factory functions for creating test entities with resolved FK relationships. **Cumulative across all domains** — `gopernicus generate <one-domain>` rewrites the file with every entity's fixtures, not just the targeted domain's, so cross-domain FK chains continue to resolve. |
 | `fixtures.go` | Once | No | Custom fixture helpers and overrides. |
 
 **E2E Tests** (`workshop/testing/e2e/`) -- for entities with HTTP routes:

--- a/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
+++ b/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
@@ -27,6 +27,8 @@ LIMIT $limit
 
 ## File-level annotations
 
+File-level annotations appear at the top of `queries.sql`, before the first `@func` block. They configure generation for the whole entity.
+
 ### `@database`
 
 Specifies which database connection pool to use for all queries in the file.
@@ -35,7 +37,26 @@ Specifies which database connection pool to use for all queries in the file.
 -- @database: analytics
 ```
 
-Must match a database name in `gopernicus.yml`. Defaults to `"primary"` if omitted. Must appear before the first `@func`.
+Must match a database name in `gopernicus.yml`. Defaults to `"primary"` if omitted.
+
+### `@skip-integration-test`
+
+Suppresses generation of the `*pgx/generated_test.go` smoke test file for the entity. A previously generated file is removed on the next `gopernicus generate` run.
+
+```sql
+-- @database: primary
+-- @skip-integration-test
+-- Nodes carries cross-column invariants the generic fixture cannot
+-- satisfy (kind='entity' requires exactly one of three nullable FKs);
+-- coverage lives in core/cases/nodecreate.
+```
+
+Use this when an entity has invariants the generic fixture default can't satisfy — typically:
+
+- **Mutually exclusive nullable FK groups.** CHECK constraints of the form `(col_a IS NOT NULL)::int + (col_b IS NOT NULL)::int = 1`. The fixture fills both columns, so any value chosen violates one branch of the CHECK.
+- **Domain-specific value invariants** that aren't expressible as a simple `IN (...)` CHECK and require the case layer to enforce.
+
+Hand-write integration tests in `*pgx/store_test.go` (which is bootstrap, not regenerated) using the `setupTestStore()` helper. The opt-out applies only to the store-level smoke test — bridge, repository, and case generation continue normally.
 
 ---
 

--- a/workshop/documentation/docs/gopernicus/workshop/testing.md
+++ b/workshop/documentation/docs/gopernicus/workshop/testing.md
@@ -192,7 +192,7 @@ Fixtures bypass the repository layer entirely (direct SQL INSERT + SELECT) for t
 
 ### Integration tests (`*pgx/generated_test.go`)
 
-Each store package gets tests for `Get`, `List`, `Delete`, and `SoftDelete` (when `record_state` exists). These run against a real PostgreSQL container:
+Each store package gets tests for `Create`, `Get`, `List`, `Delete`, and `SoftDelete` (when `record_state` exists). These run against a real PostgreSQL container:
 
 ```go
 //go:build integration
@@ -201,14 +201,72 @@ func TestGeneratedUserStore_Get(t *testing.T) {
     ctx, db, store := setupTestStore(t)
     pgxfixtures.TruncatePublicSchema(t, ctx, db.Pool)
 
-    created := fixtures.CreateTestUser(t, ctx, db)
+    created := fixtures.CreateTestUserWithDefaults(t, ctx, db)
     result, err := store.Get(ctx, created.UserID)
     require.NoError(t, err)
     assert.Equal(t, created.UserID, result.UserID)
 }
 ```
 
-The `setupTestStore` helper and `migrateTestDB` function are defined in a bootstrap file (`store_test.go`) that the generator creates once.
+The generated tests call `WithDefaults`, which auto-creates every transitive FK ancestor needed for the insert. The fixtures package is cumulative across all domains, so `gopernicus generate <one-domain>` does not wipe other domains' helpers.
+
+When a query declares scope parameters in its SQL (`@parent_world_id`, `@parent_service_account_id`, etc.), the generator threads those into the test call. So a `Get` that compiles to `Store.Get(ctx, id, parentWorldID)` is exercised as `store.Get(ctx, created.UserID, *created.ParentWorldID)` — reading the scope value off the fixture struct.
+
+The `setupTestStore` helper, `migrateTestDB` function, and `testPGXOptions` variable are defined in a bootstrap file (`store_test.go`) that the generator creates once.
+
+#### Bootstrap (`*pgx/store_test.go`)
+
+Two hooks live in the bootstrap, both of which `setupTestStore` consumes:
+
+```go
+//go:build integration
+
+package userspgx
+
+import (
+    "context"
+
+    "github.com/gopernicus/gopernicus/infrastructure/database/postgres/pgxdb"
+    "github.com/gopernicus/gopernicus/workshop/testing/testpgx"
+
+    "your-module/workshop/testing/migrationsfx"
+)
+
+// migrateTestDB applies project migrations to the freshly-spawned container.
+func migrateTestDB(ctx context.Context, pool *pgxdb.Pool) error {
+    return pgxdb.RunMigrations(ctx, pool, migrationsfx.Primary(), "migrations")
+}
+
+// testPGXOptions is appended to the testpgx.SetupTestPGX option list.
+// Use it when the default postgres:17-alpine image is missing extensions
+// your migrations need.
+var testPGXOptions = []testpgx.Option{
+    testpgx.WithPostgresVersion("pgvector/pgvector:pg17"),
+    testpgx.WithExtensions("vector", "pg_trgm"),
+}
+```
+
+`setupTestStore` does the equivalent of:
+
+```go
+opts := append([]testpgx.Option{testpgx.WithMigrations(migrateTestDB)}, testPGXOptions...)
+db := testpgx.SetupTestPGX(t, ctx, opts...)
+```
+
+so anything you add to `testPGXOptions` flows through every generated integration test in that package without editing the generated file.
+
+#### Opting out
+
+Some entities have cross-column invariants the generic fixture cannot satisfy — typically CHECK constraints that pin a mutually exclusive group of nullable FKs (e.g. a `nodes` table where `kind='entity'` requires exactly one of three tier columns). Add `-- @skip-integration-test` at the top of `queries.sql` to suppress the generated test file; any prior copy is removed on the next regeneration. Hand-write smoke tests in `store_test.go` (the bootstrap) using `setupTestStore()` directly.
+
+#### Fixture defaults the generator already knows about
+
+The fixture generator reads the reflected schema to pick sensible defaults so generated inserts pass NOT NULL and CHECK constraints out of the box:
+
+- **CHECK constraints** with an `IN (…)` or `col = 'value'` shape: the first allowed string is used. So `principal_type` defaults to `"user"` when the constraint is `principal_type IN ('user', 'service_account')`.
+- **`varchar(N)` columns** with small `N`: the default is `testUniqueID[:N]` so it fits without overflow.
+- **`json` / `jsonb` columns** (Go type `json.RawMessage`): defaults to `json.RawMessage("{}")` because Postgres rejects empty bytes as invalid JSON.
+- **Principal inheritance** (when an entity's PK is a FK to `principals`): the `principal_type` is set to the singular form of the table name (e.g. `service_accounts` → `service_account`) to match the canonical CHECK on the `principals` table.
 
 ### E2E tests (`e2e/*_generated_test.go`)
 


### PR DESCRIPTION
…are test calls

Document the fixture and integration-test generator improvements:

- New `-- @skip-integration-test` file-level annotation (annotations.md), with guidance on when to use it (mutually exclusive nullable FK groups, domain invariants the case layer must enforce).
- Integration test bootstrap section in testing.md now shows the `migrateTestDB` + `testPGXOptions` hook pattern, including a pgvector-extension example.
- Note that the fixtures package is cumulative across all domains (`gopernicus generate <one-domain>` no longer wipes other domains' helpers).
- Document the fixture-default heuristics the generator already applies: CHECK constraint allowed-value lists, varchar(N) MaxLength truncation, json.RawMessage("{}") for JSON columns, singular-table-name for principal_type on principal-inheriting tables.
- Update generate.md's file table to reflect the @skip-integration-test opt-out and the cumulative fixtures behavior.