### PR TITLE
chore: shed gopernicus-cli references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ secrets.txt
 *.env
 .env
 .env.docker
+
+# Claude Code workspace (plans, harness, memos) — local only for now
+.claude/

--- a/workshop/codegen/goversion/goversion.go
+++ b/workshop/codegen/goversion/goversion.go
@@ -1,6 +1,5 @@
 // Package goversion centralizes Go version requirements for gopernicus.
-// To bump the minimum version: update MinGoVersion, run go mod edit -go=X.Y
-// in both gopernicus/ and gopernicus-cli/, and update go.work.
+// To bump the minimum version: update MinGoVersion and run go mod edit -go=X.Y.
 package goversion
 
 import (

--- a/workshop/documentation/docs/gopernicus/intro.md
+++ b/workshop/documentation/docs/gopernicus/intro.md
@@ -59,27 +59,22 @@ Generated files are never edited directly. Instead, Gopernicus generates [bootst
 
 ## Installation
 
-```bash
-go install github.com/gopernicus/gopernicus-cli@latest
-```
-
-`go install` places the binary in your `$GOBIN` directory (defaults to `$HOME/go/bin`). Make sure it's on your PATH:
+There is nothing to install. Bootstrap a project straight from the module proxy:
 
 ```bash
-# Linux / macOS — add to your ~/.bashrc, ~/.zshrc, or equivalent
-export PATH="$HOME/go/bin:$PATH"
-```
-
-```powershell
-# Windows (PowerShell) — add to your profile or set via System > Environment Variables
-$env:Path = "$env:USERPROFILE\go\bin;$env:Path"
-```
-
-Initialize a new project:
-
-```bash
-gopernicus init myapp
+go run github.com/gopernicus/gopernicus/workshop/gopernicus@latest init myapp
 cd myapp
 ```
+
+Inside the project, every command runs through the version-pinned tool:
+
+```bash
+go tool gopernicus generate
+go tool gopernicus db migrate
+```
+
+The project's `go.mod` carries a `tool` directive pinning the generator to the
+same framework version the project links, so generated code and runtime can
+never drift.
 
 See [CLI: init](../cli/init.md) for all initialization options (authentication, authorization, tenancy, events).

--- a/workshop/documentation/docs/gopernicus/topics/running-from-source.md
+++ b/workshop/documentation/docs/gopernicus/topics/running-from-source.md
@@ -5,53 +5,36 @@ title: Running from Source
 
 # Running from Source
 
-If you want to contribute to Gopernicus, test unreleased changes, or init projects from your own fork, you can run the CLI directly from source.
+If you want to contribute to Gopernicus, test unreleased changes, or init projects from your own fork, you can run the tool directly from a local checkout.
 
 ## Fork and Clone
 
-Fork both repositories on GitHub, then clone them into the same parent directory:
+Fork the repository on GitHub, then clone it:
 
 ```bash
-mkdir -p ~/code/gopernicus && cd ~/code/gopernicus
-
-# Framework (the Go module with core, bridge, infrastructure, etc.)
-git clone https://github.com/<your-username>/gopernicus.git gopernicus
-
-# CLI (the gopernicus command)
-git clone https://github.com/<your-username>/gopernicus-cli.git gopernicus-cli
+git clone https://github.com/<your-username>/gopernicus.git ~/code/gopernicus
 ```
 
-## Set Up a Go Workspace (optional)
+Everything lives in one module — the framework and the generator tool (`workshop/gopernicus`) version together.
 
-A [Go workspace](https://go.dev/doc/tutorial/workspaces) lets the CLI resolve the framework module locally without publishing:
+## Bootstrapping Projects from Your Checkout
+
+`GOPERNICUS_DEV_SOURCE` tells `init` to use your local framework instead of a published release. The scaffolded project gets a `replace` directive pointing at your checkout, so `go tool gopernicus` inside it also runs your local code:
 
 ```bash
-cd ~/code/gopernicus
-go work init ./gopernicus ./gopernicus-cli
+GOPERNICUS_DEV_SOURCE=~/code/gopernicus \
+  go run ~/code/gopernicus/workshop/gopernicus init testapp --no-interactive
 ```
 
-This creates a `go.work` file that tells Go to use your local copies instead of fetching from the module proxy.
-
-## Shell Aliases
-
-Add these to your `~/.bashrc`, `~/.zshrc`, or equivalent:
+A shell function makes this comfortable — add to your `~/.bashrc`, `~/.zshrc`, or equivalent:
 
 ```bash
-# Run the CLI from source, using your local framework checkout.
-# GOPERNICUS_DEV_SOURCE tells `gopernicus init` to copy files from your
-# local framework instead of downloading from the module cache.
+# Run the gopernicus tool from your local checkout; projects it
+# scaffolds link your local framework too.
 gopernicus-local(){
-  GOPERNICUS_DEV_SOURCE=~/code/gopernicus/gopernicus \
-  GOWORK=~/code/gopernicus/go.work \
+  GOPERNICUS_DEV_SOURCE=~/code/gopernicus \
   GOTOOLCHAIN=local \
-    go run ~/code/gopernicus/gopernicus-cli "$@"
-}
-
-# Run the CLI from source without the dev source override.
-# Uses the published framework module but your local CLI code.
-gopernicus(){
-  GOWORK=~/code/gopernicus/go.work \
-    go run ~/code/gopernicus/gopernicus-cli "$@"
+    go run ~/code/gopernicus/workshop/gopernicus "$@"
 }
 ```
 
@@ -65,12 +48,11 @@ gopernicus-local version
 
 | Variable | Purpose |
 |---|---|
-| `GOPERNICUS_DEV_SOURCE` | Path to a local framework checkout. When set, `gopernicus init` copies migrations, repositories, bridges, and documentation from this directory instead of fetching from the Go module cache. |
-| `GOWORK` | Path to a `go.work` file. Tells Go to resolve modules from the workspace rather than the module proxy. |
+| `GOPERNICUS_DEV_SOURCE` | Path to a local framework checkout. When set, `init` copies migrations, repositories, bridges, and documentation from this directory instead of fetching from the Go module cache, and writes a `replace` directive into the new project. |
 | `GOTOOLCHAIN=local` | Forces Go to use your locally installed toolchain instead of auto-downloading a newer one. Useful when working offline or pinning a specific Go version. |
 
 ## Typical Workflow
 
-1. Make changes to the framework (`gopernicus/`) or CLI (`gopernicus-cli/`)
-2. Test with `gopernicus-local init testapp` — your local changes are used
-3. When ready, open PRs against both repos as needed
+1. Make changes to the framework or the generator (same repo)
+2. Test with `gopernicus-local init testapp` — your local changes are used everywhere, including `go tool gopernicus` inside the test project
+3. When ready, open a PR

--- a/workshop/documentation/docs/gopernicus/zero-to-api.md
+++ b/workshop/documentation/docs/gopernicus/zero-to-api.md
@@ -11,22 +11,21 @@ your own names throughout.
 
 ## Prerequisites
 
-- Go 1.23+ installed
+- Go 1.24+ installed (the generator runs via the go.mod `tool` directive)
 - Docker (for PostgreSQL and Redis)
-- The gopernicus CLI:
-  ```bash
-  go install github.com/gopernicus/gopernicus-cli@latest
-  ```
 
 ## 1. Create the Project
 
+Nothing to install — bootstrap straight from the module proxy:
+
 ```bash
-gopernicus init myapp
+go run github.com/gopernicus/gopernicus/workshop/gopernicus@latest init myapp
 cd myapp
 ```
 
-The interactive wizard walks you through feature selection. For this guide,
-accept the defaults (all features enabled).
+Omitted flags use the defaults (all features enabled), which is what this
+guide assumes. After init, every command runs through the project-pinned
+tool: `go tool gopernicus <command>`.
 
 After init completes you have a full project structure: `app/server/`, `core/`,
 `bridge/`, `workshop/`, a `Makefile`, `.env`, and `gopernicus.yml`.

--- a/workshop/gopernicus/commands/init.go
+++ b/workshop/gopernicus/commands/init.go
@@ -11,17 +11,15 @@ import (
 func init() {
 	cli.RegisterCommand(&cli.Command{
 		Name:  "init",
-		Short: "Bootstrap a new gopernicus project (flags only)",
+		Short: "Bootstrap a new gopernicus project",
 		Long: `Bootstrap a new gopernicus project in a new directory.
 
 Scaffolds a project directory with go.mod, gopernicus.yml, and a minimal
-directory layout ready for 'gopernicus generate'. This in-framework tool is
-flags-only: every choice is a flag, and omitted flags use the defaults (all
-features, default infrastructure). For the interactive picker experience,
-use the gopernicus CLI: go run github.com/gopernicus/gopernicus-cli@latest init
+directory layout ready for 'gopernicus generate'. Every choice is a flag;
+omitted flags use the defaults (all features, default infrastructure).
 
-Bootstrap a project with no second install:
-  go run github.com/gopernicus/gopernicus/workshop/gopernicus@latest init myapp --no-interactive
+Bootstrap a project with no install:
+  go run github.com/gopernicus/gopernicus/workshop/gopernicus@latest init myapp
 
 Examples:
   gopernicus init myapp
@@ -40,10 +38,9 @@ func runInit(_ context.Context, args []string) error {
 		return err
 	}
 
-	// This tool has no TUI: init is always non-interactive here. When the
-	// user didn't ask for that explicitly, point at the CLI's picker flow.
+	// init is flag-driven; omitted flags mean defaults.
 	if !opts.NoInteractive {
-		fmt.Println("note: using defaults — the interactive picker lives in the gopernicus CLI (go run github.com/gopernicus/gopernicus-cli@latest init)")
+		fmt.Println("note: using defaults — pass --features/--module to customize")
 		opts.NoInteractive = true
 	}
 


### PR DESCRIPTION
gopernicus-cli is archived — this removes every operational reference: tool init help/note, install docs (now `go run …/workshop/gopernicus@latest init` + `go tool gopernicus`), running-from-source rewritten single-repo, stale goversion comment, and gitignores `.claude/`. Matrix 12/12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)