### PR TITLE
ci: add CI gates (build/unit, tagged-compile, clean-regenerate, integration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
   build-and-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -34,9 +34,9 @@ jobs:
   tagged-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -52,9 +52,9 @@ jobs:
   clean-regenerate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -72,9 +72,9 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Unit tests
+        run: go test ./... -count=1
+
+  tagged-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Vet (integration)
+        run: go vet -tags=integration ./...
+
+      - name: Vet (e2e)
+        run: go vet -tags=e2e ./...
+
+      - name: Vet (penetration)
+        run: go vet -tags=penetration ./...
+
+  clean-regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Regenerate
+        run: go run ./workshop/gopernicus generate
+
+      - name: Verify no drift
+        run: |
+          git add -A
+          if ! git diff --cached --exit-code; then
+            echo "::error::Generated files are stale or generation is nondeterministic — run 'gopernicus generate' and commit the result."
+            exit 1
+          fi
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Integration tests
+        run: go test -tags=integration -timeout 10m ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopernicus/gopernicus
 
-go 1.25.0
+go 1.26
 
 require (
 	cloud.google.com/go/storage v1.60.0

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 SHELL_PATH := /bin/ash
 SHELL := $(if $(wildcard $(SHELL_PATH)),/bin/ash,/bin/bash)
 
-GOLANG := golang:1.25
+GOLANG := golang:1.26
 
 NAMESPACE := gopernicus
 IMAGE_NAME := localhost/gopernicus


### PR DESCRIPTION
## Summary

Item 1 of the v0.3.x hygiene plan (`.claude/roadmap/plan-v0.3.x-hygiene.md`): the repo's only workflow until now was deploy-docs, which let two failure classes through this cycle — `-tags=integration` broken at HEAD (orphaned jobqueuepgx test) and generated files drifting stale against the generator until a manual regenerate during v0.3.1.

Four jobs, all on `ubuntu-latest`, Go pinned from `go.mod`:

1. **build-and-unit** — `go build`, `go vet`, `go test -count=1` (no docker)
2. **tagged-compile** — `go vet` under `integration`/`e2e`/`penetration` tags; catches the orphaned-tagged-test class without paying container time
3. **clean-regenerate** — `go run ./workshop/gopernicus generate` then drift check (`git add -A` + `git diff --cached --exit-code`, so untracked emissions fail too). Runs offline against the committed `_public.json` snapshot, no database needed.
4. **integration** — `go test -tags=integration -timeout 10m ./...` via testcontainers on the runner's docker. Plan calls for a budget check on the first run; if it exceeds ~8min we gate it to main + nightly.

All four commands verified green locally before pushing.

## Follow-ups (per plan)
- Branch protection requiring jobs 1–3 once green on main.
- Badge: the plan lists a README badge, but the repo has no root README (docs live in the Docusaurus site) — needs a decision on where it goes.
- Item 2 of the plan (`@fixture-default` annotation) rides the same patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)