### PR TITLE
feat(codegen): @fixture-default annotation — per-column fixture overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
   build-and-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -34,9 +34,9 @@ jobs:
   tagged-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -52,9 +52,9 @@ jobs:
   clean-regenerate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -72,9 +72,9 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Unit tests
+        run: go test ./... -count=1
+
+  tagged-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Vet (integration)
+        run: go vet -tags=integration ./...
+
+      - name: Vet (e2e)
+        run: go vet -tags=e2e ./...
+
+      - name: Vet (penetration)
+        run: go vet -tags=penetration ./...
+
+  clean-regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Regenerate
+        run: go run ./workshop/gopernicus generate
+
+      - name: Verify no drift
+        run: |
+          git add -A
+          if ! git diff --cached --exit-code; then
+            echo "::error::Generated files are stale or generation is nondeterministic — run 'gopernicus generate' and commit the result."
+            exit 1
+          fi
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Integration tests
+        run: go test -tags=integration -timeout 10m ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopernicus/gopernicus
 
-go 1.25.0
+go 1.26
 
 require (
 	cloud.google.com/go/storage v1.60.0

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 SHELL_PATH := /bin/ash
 SHELL := $(if $(wildcard $(SHELL_PATH)),/bin/ash,/bin/bash)
 
-GOLANG := golang:1.25
+GOLANG := golang:1.26
 
 NAMESPACE := gopernicus
 IMAGE_NAME := localhost/gopernicus

--- a/workshop/codegen/generators/fixture.go
+++ b/workshop/codegen/generators/fixture.go
@@ -211,12 +211,44 @@ func BuildFixtureEntity(resolved *ResolvedFile, modulePath string) FixtureEntity
 		}
 	}
 
+	// @fixture-default overrides are the final pass — they win over the
+	// generic, enum, and length-capped defaults. PK and FK columns are
+	// rejected at resolve time, so param wiring above is never clobbered.
+	for i, f := range entity.InsertFields {
+		if raw, ok := resolved.FixtureDefaults[f.DBName]; ok {
+			entity.InsertFields[i].TestDefault = fixtureDefaultExpr(f, raw)
+		}
+	}
+
 	// Build AllColumns for SELECT back.
 	for _, col := range resolved.AllColumns {
 		entity.AllColumns = append(entity.AllColumns, columnToFixture(col))
 	}
 
 	return entity
+}
+
+// fixtureDefaultExpr renders an author-supplied @fixture-default value as a
+// Go expression for the column's type. Values were validated in Resolve;
+// only representation decisions live here.
+func fixtureDefaultExpr(f FixtureField, raw string) string {
+	inner := strings.TrimPrefix(f.GoType, "*")
+
+	var expr string
+	switch inner {
+	case "string":
+		expr = fmt.Sprintf("%q", raw)
+	case "json.RawMessage":
+		expr = fmt.Sprintf("json.RawMessage(`%s`)", raw)
+	default:
+		// bool/int/float literals emit verbatim (sanity-checked in Resolve).
+		expr = raw
+	}
+
+	if strings.HasPrefix(f.GoType, "*") {
+		return fmt.Sprintf("conversion.Ptr(%s)", expr)
+	}
+	return expr
 }
 
 // buildParentFixtures extracts FK dependencies from a table.

--- a/workshop/codegen/generators/fixture_test.go
+++ b/workshop/codegen/generators/fixture_test.go
@@ -92,6 +92,102 @@ func TestPrincipalInheritanceFixtureUsesCheckValidType(t *testing.T) {
 	}
 }
 
+// fixtureDefaultsResolved builds a tenant_secrets-shaped entity carrying
+// resolved @fixture-default overrides for string, json, bool, and nullable
+// pointer columns.
+func fixtureDefaultsResolved() *ResolvedFile {
+	return &ResolvedFile{
+		Table:       &schema.TableInfo{TableName: "tenant_secrets"},
+		EntityName:  "TenantSecret",
+		EntityLower: "tenantsecret",
+		TableName:   "tenant_secrets",
+		PackageName: "tenantsecrets",
+		DomainName:  "tenancy",
+		PKColumn:    "secret_id",
+		PKGoName:    "SecretID",
+		PKGoType:    "string",
+		AllColumns: []schema.ColumnInfo{
+			{Name: "secret_id", DBType: "text", GoType: "string", IsPrimaryKey: true},
+			{Name: "payload", DBType: "jsonb", GoType: "json.RawMessage", GoImport: "encoding/json"},
+			{Name: "kind", DBType: "text", GoType: "string"},
+			{Name: "note", DBType: "text", GoType: "*string", IsNullable: true},
+			{Name: "enabled", DBType: "boolean", GoType: "bool"},
+		},
+		FixtureDefaults: map[string]string{
+			"payload": `{"backend":"db","ciphertext":"dGVzdA=="}`,
+			"kind":    "entity",
+			"note":    "pinned",
+			"enabled": "true",
+		},
+	}
+}
+
+// @fixture-default overrides must win over the generic test defaults, with
+// type-appropriate rendering: quoted strings, raw-string json.RawMessage,
+// verbatim bools, and conversion.Ptr wrapping for nullable pointer columns.
+func TestFixtureDefaultOverridesEmitted(t *testing.T) {
+	dir := t.TempDir()
+	data := FixtureTemplateData{
+		ModulePath: "example.com/app",
+		Entities:   []FixtureEntity{BuildFixtureEntity(fixtureDefaultsResolved(), "example.com/app")},
+	}
+	if err := GenerateFixtures(data, dir, Options{}); err != nil {
+		t.Fatalf("GenerateFixtures: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "generated.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(out)
+
+	for _, want := range []string{
+		"json.RawMessage(`{\"backend\":\"db\",\"ciphertext\":\"dGVzdA==\"}`)",
+		`"entity"`,
+		`conversion.Ptr("pinned")`,
+		"true",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("generated fixture missing override %s", want)
+		}
+	}
+	if strings.Contains(content, `"test_kind`) {
+		t.Error("generic default must not survive a @fixture-default override")
+	}
+	if strings.Contains(content, `json.RawMessage("{}")`) {
+		t.Error("generic JSON default must not survive a @fixture-default override")
+	}
+}
+
+// Spec-mode fixtures share BuildFixtureEntity, so overrides must carry
+// through GenerateSpecFixtures unchanged.
+func TestFixtureDefaultOverridesEmittedSpecMode(t *testing.T) {
+	dir := t.TempDir()
+	data := FixtureTemplateData{
+		ModulePath: "example.com/app",
+		Entities:   []FixtureEntity{BuildFixtureEntity(fixtureDefaultsResolved(), "example.com/app")},
+	}
+	if err := GenerateSpecFixtures(data, dir, Options{}); err != nil {
+		t.Fatalf("GenerateSpecFixtures: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "generated.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(out)
+
+	for _, want := range []string{
+		"json.RawMessage(`{\"backend\":\"db\",\"ciphertext\":\"dGVzdA==\"}`)",
+		`"entity"`,
+		`conversion.Ptr("pinned")`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("spec-mode fixture missing override %s", want)
+		}
+	}
+}
+
 // Without a principals entity in the batch, the fallback is "user" — the
 // first value the framework-shipped principals_type_check allows.
 func TestPrincipalInheritanceFixtureFallsBackToUser(t *testing.T) {

--- a/workshop/codegen/generators/parse.go
+++ b/workshop/codegen/generators/parse.go
@@ -37,6 +37,8 @@ func ParseString(input string) (*File, error) {
 			if v, ok := annotations[lastAnnotationKey]; ok {
 				annotations[lastAnnotationKey] = v + " " + continuation
 			}
+		} else if !inQuery && lastAnnotationKey == "fixture-default" && len(f.FixtureDefaults) > 0 {
+			f.FixtureDefaults[len(f.FixtureDefaults)-1] += " " + continuation
 		} else if !inQuery && f.FileAnnotations != nil {
 			if v, ok := f.FileAnnotations[lastAnnotationKey]; ok {
 				f.FileAnnotations[lastAnnotationKey] = v + " " + continuation
@@ -172,6 +174,19 @@ func ParseString(input string) (*File, error) {
 				}
 
 				if !inQuery {
+					// @fixture-default is repeatable (one column per line) —
+					// accumulate instead of letting the map overwrite. The
+					// named form `@fixture-default:col value` normalizes to
+					// the standard "col value" entry.
+					if key == "fixture-default" {
+						lastAnnotationKey = key
+						entry := val
+						if name != "" {
+							entry = strings.TrimSpace(name + " " + val)
+						}
+						f.FixtureDefaults = append(f.FixtureDefaults, entry)
+						continue
+					}
 					if f.FileAnnotations == nil {
 						f.FileAnnotations = make(map[string]string)
 					}

--- a/workshop/codegen/generators/parse_test.go
+++ b/workshop/codegen/generators/parse_test.go
@@ -283,6 +283,55 @@ SELECT count(*) FROM events WHERE tenant_id = @tenant_id;
 	}
 }
 
+func TestParseString_FixtureDefaults(t *testing.T) {
+	input := `-- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
+-- @fixture-default: kind entity
+-- @fixture-default:named_form value with spaces
+
+-- @func: Get
+SELECT * FROM tenant_secrets WHERE secret_id = @secret_id;
+`
+	f, err := ParseString(input)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	want := []string{
+		`payload {"backend":"db","ciphertext":"dGVzdA=="}`,
+		"kind entity",
+		"named_form value with spaces",
+	}
+	if len(f.FixtureDefaults) != len(want) {
+		t.Fatalf("FixtureDefaults = %v, want %d entries", f.FixtureDefaults, len(want))
+	}
+	for i, w := range want {
+		if f.FixtureDefaults[i] != w {
+			t.Errorf("FixtureDefaults[%d] = %q, want %q", i, f.FixtureDefaults[i], w)
+		}
+	}
+	if _, ok := f.FileAnnotations["fixture-default"]; ok {
+		t.Error("fixture-default must not land in FileAnnotations")
+	}
+}
+
+func TestParseString_FixtureDefaultContinuation(t *testing.T) {
+	input := `-- @fixture-default: kind entity
+-- | extended
+
+-- @func: Get
+SELECT * FROM tenant_secrets WHERE secret_id = @secret_id;
+`
+	f, err := ParseString(input)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	if len(f.FixtureDefaults) != 1 {
+		t.Fatalf("FixtureDefaults = %v, want 1 entry", f.FixtureDefaults)
+	}
+	if !strings.HasPrefix(f.FixtureDefaults[0], "kind entity ") {
+		t.Errorf("continuation must append to the last fixture-default, got %q", f.FixtureDefaults[0])
+	}
+}
+
 func TestParseString_SQLOutsideBlock(t *testing.T) {
 	input := `SELECT * FROM users;`
 	_, err := ParseString(input)

--- a/workshop/codegen/generators/resolve.go
+++ b/workshop/codegen/generators/resolve.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -63,6 +64,13 @@ func Resolve(qf *File, s *schema.ReflectedSchema, domainName string) (*ResolvedF
 
 	_, skipIntegrationTest := qf.FileAnnotations["skip-integration-test"]
 
+	colMap := buildColumnMap(table)
+
+	fixtureDefaults, err := resolveFixtureDefaults(qf.FixtureDefaults, table, colMap)
+	if err != nil {
+		return nil, fmt.Errorf("@fixture-default: %w", err)
+	}
+
 	rf := &ResolvedFile{
 		Table:               table,
 		SchemaName:          s.SchemaName,
@@ -78,9 +86,8 @@ func Resolve(qf *File, s *schema.ReflectedSchema, domainName string) (*ResolvedF
 		PKGoName:            pkGoName,
 		PKGoType:            pkGoType,
 		SkipIntegrationTest: skipIntegrationTest,
+		FixtureDefaults:     fixtureDefaults,
 	}
-
-	colMap := buildColumnMap(table)
 
 	// Build a cross-table column lookup for resolving JOIN/CTE columns.
 	allColMap := buildAllColumnMap(s.Tables)
@@ -363,6 +370,74 @@ func resolveASTColumn(col ASTColumn, aliasMap map[string]string, cteTypeMap map[
 		DBName: col.Name,
 		IsTime: goType == "*time.Time" || goType == "time.Time",
 	}
+}
+
+// resolveFixtureDefaults validates raw `@fixture-default: <column> <value>`
+// entries against the table schema and returns a column → raw value map.
+// General CHECK-constraint evaluation is explicitly not the goal —
+// author-supplied values are. Anything unresolvable is a hard generation
+// error naming the offending entry: a silently wrong fixture would defeat
+// the point of the annotation.
+func resolveFixtureDefaults(entries []string, table *schema.TableInfo, colMap map[string]schema.ColumnInfo) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	defaults := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		column, value, found := strings.Cut(strings.TrimSpace(entry), " ")
+		if !found || strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("entry %q: want `<column> <value>`", entry)
+		}
+		value = strings.TrimSpace(value)
+
+		col, ok := colMap[column]
+		if !ok {
+			return nil, fmt.Errorf("column %q not found in table %q", column, table.TableName)
+		}
+		if _, dup := defaults[column]; dup {
+			return nil, fmt.Errorf("column %q declared more than once", column)
+		}
+		if col.IsPrimaryKey {
+			return nil, fmt.Errorf("column %q is the primary key — fixtures generate unique PKs themselves", column)
+		}
+		if col.IsForeignKey {
+			return nil, fmt.Errorf("column %q is a foreign key — FK values come from parent fixture wiring", column)
+		}
+
+		goType := strings.TrimPrefix(col.GoType, "*")
+		switch goType {
+		case "string":
+			// Any value works — the generator emits it as a quoted literal.
+		case "json.RawMessage":
+			if !json.Valid([]byte(value)) {
+				return nil, fmt.Errorf("column %q: value is not valid JSON: %s", column, value)
+			}
+			if strings.Contains(value, "`") {
+				return nil, fmt.Errorf("column %q: JSON value must not contain backticks (emitted as a raw string literal)", column)
+			}
+		case "bool":
+			if value != "true" && value != "false" {
+				return nil, fmt.Errorf("column %q: bool value must be `true` or `false`, got %q", column, value)
+			}
+		case "int", "int32", "int64":
+			if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+				return nil, fmt.Errorf("column %q: invalid integer value %q", column, value)
+			}
+		case "float64":
+			if _, err := strconv.ParseFloat(value, 64); err != nil {
+				return nil, fmt.Errorf("column %q: invalid float value %q", column, value)
+			}
+		case "time.Time":
+			return nil, fmt.Errorf("column %q: time columns cannot be overridden", column)
+		default:
+			return nil, fmt.Errorf("column %q: unsupported column type %s", column, col.GoType)
+		}
+
+		defaults[column] = value
+	}
+
+	return defaults, nil
 }
 
 // resolveSearchSpec parses "@search: ilike(field1, field2)" and returns FieldInfo entries.

--- a/workshop/codegen/generators/resolve_test.go
+++ b/workshop/codegen/generators/resolve_test.go
@@ -1,0 +1,123 @@
+package generators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gopernicus/gopernicus/workshop/codegen/schema"
+)
+
+// fixtureDefaultsSchema builds a tenant_secrets-shaped table: the JSON
+// payload + CHECK-constrained kind columns that motivated @fixture-default,
+// plus PK/FK/time/numeric columns for the rejection cases.
+func fixtureDefaultsSchema() *schema.ReflectedSchema {
+	cols := []schema.ColumnInfo{
+		{Name: "secret_id", DBType: "text", GoType: "string", IsPrimaryKey: true},
+		{Name: "tenant_id", DBType: "text", GoType: "string", IsForeignKey: true},
+		{Name: "payload", DBType: "jsonb", GoType: "json.RawMessage", GoImport: "encoding/json"},
+		{Name: "kind", DBType: "text", GoType: "string"},
+		{Name: "note", DBType: "text", GoType: "*string", IsNullable: true},
+		{Name: "enabled", DBType: "boolean", GoType: "bool"},
+		{Name: "version", DBType: "integer", GoType: "int"},
+		{Name: "weight", DBType: "double precision", GoType: "float64"},
+		{Name: "rotated_at", DBType: "timestamptz", GoType: "time.Time", GoImport: "time"},
+	}
+	return &schema.ReflectedSchema{
+		SchemaName: "public",
+		Tables: map[string]*schema.TableInfo{
+			"tenant_secrets": {
+				TableName: "tenant_secrets",
+				Schema:    "public",
+				PrimaryKey: &schema.PrimaryKeyInfo{
+					Column: "secret_id",
+					DBType: "text",
+					GoType: "string",
+				},
+				Columns: cols,
+			},
+		},
+	}
+}
+
+func resolveWithFixtureDefaults(t *testing.T, entries ...string) (*ResolvedFile, error) {
+	t.Helper()
+	input := ""
+	for _, e := range entries {
+		input += "-- @fixture-default: " + e + "\n"
+	}
+	input += `
+-- @func: Get
+SELECT * FROM tenant_secrets WHERE secret_id = @secret_id;
+`
+	qf, err := ParseString(input)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	qf.Table = "tenant_secrets"
+	return Resolve(qf, fixtureDefaultsSchema(), "tenancy")
+}
+
+func TestResolveFixtureDefaults_Valid(t *testing.T) {
+	resolved, err := resolveWithFixtureDefaults(t,
+		`payload {"backend":"db","ciphertext":"dGVzdA=="}`,
+		"kind entity",
+		"enabled true",
+		"version 3",
+		"weight 0.5",
+	)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := map[string]string{
+		"payload": `{"backend":"db","ciphertext":"dGVzdA=="}`,
+		"kind":    "entity",
+		"enabled": "true",
+		"version": "3",
+		"weight":  "0.5",
+	}
+	for col, val := range want {
+		if resolved.FixtureDefaults[col] != val {
+			t.Errorf("FixtureDefaults[%s] = %q, want %q", col, resolved.FixtureDefaults[col], val)
+		}
+	}
+}
+
+func TestResolveFixtureDefaults_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   string
+		wantErr string
+	}{
+		{"unknown column", "missing_col x", "not found"},
+		{"missing value", "kind", "want `<column> <value>`"},
+		{"primary key", "secret_id custom", "primary key"},
+		{"foreign key", "tenant_id custom", "foreign key"},
+		{"bad json", "payload {not-json", "not valid JSON"},
+		{"json backtick", "payload {\"a\":\"`\"}", "backtick"},
+		{"bad bool", "enabled yes", "must be `true` or `false`"},
+		{"bad int", "version three", "invalid integer"},
+		{"bad float", "weight heavy", "invalid float"},
+		{"time column", "rotated_at 2026-01-01", "time columns"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveWithFixtureDefaults(t, tc.entry)
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.entry)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveFixtureDefaults_DuplicateColumn(t *testing.T) {
+	_, err := resolveWithFixtureDefaults(t, "kind entity", "kind other")
+	if err == nil {
+		t.Fatal("expected error for duplicate column")
+	}
+	if !strings.Contains(err.Error(), "more than once") {
+		t.Errorf("error %q does not mention duplication", err)
+	}
+}

--- a/workshop/codegen/generators/types.go
+++ b/workshop/codegen/generators/types.go
@@ -19,6 +19,12 @@ type File struct {
 	// (databases.<name>.domains) is the binding source.
 	FileAnnotations map[string]string
 
+	// FixtureDefaults holds raw `@fixture-default: <column> <value>` entries
+	// in file order. Repeatable — accumulated separately because
+	// FileAnnotations overwrites duplicate keys. Validated against the
+	// schema in Resolve.
+	FixtureDefaults []string
+
 	Queries []QueryBlock
 }
 
@@ -137,6 +143,13 @@ type ResolvedFile struct {
 	// nullable FK groups) that the generic fixture cannot satisfy —
 	// hand-write the desired tests in store_test.go instead.
 	SkipIntegrationTest bool
+
+	// FixtureDefaults maps column name → raw author-supplied value from
+	// file-level `-- @fixture-default: <column> <value>` annotations.
+	// Validated in Resolve (column exists, not PK/FK/time, value parses for
+	// the column's type); applied as the final TestDefault override in
+	// BuildFixtureEntity.
+	FixtureDefaults map[string]string
 
 	Queries []ResolvedQuery
 }

--- a/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
+++ b/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
@@ -45,6 +45,31 @@ Use this when an entity has invariants the generic fixture default can't satisfy
 
 Hand-write integration tests in `*pgx/store_test.go` (which is bootstrap, not regenerated) using the `setupTestStore()` helper. The opt-out applies only to the store-level smoke test — bridge, repository, and case generation continue normally.
 
+Before reaching for the opt-out, check whether `@fixture-default` (below) solves it: if the constraint can be satisfied by pinning one or two column values, the override keeps the entity inside the generated path.
+
+### `@fixture-default`
+
+Overrides the generated test fixture's value for one column. Repeatable — one column per line. The answer to arbitrary CHECK constraints the generic fixture can't satisfy (cross-column predicates, JSON shape requirements): supply a value that does, and the generated smoke tests keep running.
+
+```sql
+-- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
+-- @fixture-default: kind entity
+```
+
+Grammar: `@fixture-default: <column> <value>` — everything after the first space is the value.
+
+| Column type | Value handling |
+|-------------|----------------|
+| string | Used as the literal; the generator quotes it |
+| json / jsonb | Validated as JSON at generation time, emitted as `json.RawMessage` |
+| bool | Must be `true` or `false`, emitted verbatim |
+| int / float | Type-checked, emitted verbatim |
+| nullable (pointer) | Value wrapped in `conversion.Ptr(...)` |
+
+An unknown column, an unparseable value, or an attempt to override a primary key, foreign key, or time column is a hard generation error naming the file — fail loud, never a silently wrong fixture. FK values always come from parent fixture wiring; PKs are generated uniquely per test row.
+
+General CHECK-constraint evaluation is explicitly not the goal — author-supplied values are. If no fixed per-column value can satisfy the invariant (e.g. mutually exclusive nullable FK groups), fall back to `@skip-integration-test`.
+
 ---
 
 ## Query-level annotations

--- a/workshop/documentation/docs/gopernicus/workshop/testing.md
+++ b/workshop/documentation/docs/gopernicus/workshop/testing.md
@@ -257,7 +257,20 @@ so anything you add to `testPGXOptions` flows through every generated integratio
 
 #### Opting out
 
-Some entities have cross-column invariants the generic fixture cannot satisfy — typically CHECK constraints that pin a mutually exclusive group of nullable FKs (e.g. a `nodes` table where `kind='entity'` requires exactly one of three tier columns). Add `-- @skip-integration-test` at the top of `queries.sql` to suppress the generated probes. The next regeneration replaces `generated_test.go` with a **setup-only** version: no test functions, but the `setupTestStore()` helper stays available. Hand-write smoke tests in `store_test.go` (the bootstrap) using it directly.
+The escape-hatch ladder, in order:
+
+1. **Do nothing** — the generator's built-in defaults (below) satisfy NOT NULL, simple `IN (…)` CHECKs, and length caps on their own.
+2. **`@fixture-default`** — when a constraint needs a specific value the generator can't infer (an arbitrary CHECK predicate, a JSON shape requirement), pin that column's fixture value and keep the generated probes running:
+
+   ```sql
+   -- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
+   -- @fixture-default: kind entity
+   ```
+
+   One column per line; see the [annotations reference](../topics/code-generation/annotations.md#fixture-default) for the grammar and per-type value handling.
+3. **`@skip-integration-test`** — last resort, when no fixed per-column value can satisfy the invariant.
+
+Some entities have cross-column invariants no fixed fixture value can satisfy — typically CHECK constraints that pin a mutually exclusive group of nullable FKs (e.g. a `nodes` table where `kind='entity'` requires exactly one of three tier columns). Add `-- @skip-integration-test` at the top of `queries.sql` to suppress the generated probes. The next regeneration replaces `generated_test.go` with a **setup-only** version: no test functions, but the `setupTestStore()` helper stays available. Hand-write smoke tests in `store_test.go` (the bootstrap) using it directly.
 
 The same setup-only emission applies automatically to entities where no standard probe is usable from the generic fixtures (no single-PK `Get`, or scope params reading columns the fixtures seed as NULL) — the generation output notes each one.
 


### PR DESCRIPTION
## Summary

Item 2 of the v0.3.x hygiene plan, stacked on #25. Closes segovia findings item 5 — the last open one: `tenant_secrets_payload_check`-style arbitrary CHECK constraints previously forced `@skip-integration-test` + fully hand-written fixtures. A file-level, repeatable annotation now pins the generated fixture's value per column, keeping such entities inside the generated path:

```sql
-- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
-- @fixture-default: kind entity
```

## Design (per `.claude/roadmap/plan-v0.3.x-hygiene.md`)

- **Parse**: entries accumulate into `File.FixtureDefaults []string` (the `FileAnnotations` map overwrites duplicate keys), with pipe-continuation support; the named form `@fixture-default:col value` normalizes to the standard entry.
- **Resolve**: validates against the reflected schema and fails generation loudly — unknown column, unparseable value (JSON/bool/int/float per column type), duplicate column, or an attempt to override a PK, FK, or time column. General CHECK evaluation is explicitly not the goal; author-supplied values are.
- **Fixture**: overrides applied as the final `TestDefault` pass in `BuildFixtureEntity` — quoted strings, raw-string `json.RawMessage`, verbatim bool/int/float, `conversion.Ptr(...)` for nullable pointer columns. FK param wiring can never be clobbered (rejected at resolve). Spec-mode (sqlite) fixtures share the same path; `specEncodeTimeDefaults` is untouched since time overrides are rejected.
- **Docs**: annotations.md gains the section with the tenant_secrets example; testing.md's opt-out section now reads as an escape-hatch ladder with `@fixture-default` as the step before `@skip-integration-test`.

## Tests

- Parse: accumulation/order, named-form normalization, continuation, no FileAnnotations leakage.
- Resolve: valid map population + 10 error cases (unknown column, missing value, PK/FK/time rejection, bad JSON/bool/int/float, backtick-in-JSON, duplicate column).
- Emitted fixtures: golden-fragment checks for string/json/bool/pointer overrides in both pgx and spec mode, and that generic defaults don't survive an override.

`go build ./...`, `go vet ./...`, `go test ./...`, and a clean `gopernicus generate` (no drift) all verified locally.

## Follow-up

Segovia rides the next repin: tenantsecrets declares a payload default and drops `@skip-integration-test`, re-enabling its generated probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)