### PR TITLE
feat(codegen): @fixture-default null — pin nullable columns to SQL NULL

### DIFF
--- a/workshop/codegen/generators/fixture.go
+++ b/workshop/codegen/generators/fixture.go
@@ -232,6 +232,12 @@ func BuildFixtureEntity(resolved *ResolvedFile, modulePath string) FixtureEntity
 // Go expression for the column's type. Values were validated in Resolve;
 // only representation decisions live here.
 func fixtureDefaultExpr(f FixtureField, raw string) string {
+	// `null` pins a nullable column to SQL NULL (nil binds NULL for both
+	// pointer and slice-backed types). Resolve rejects it on NOT NULL columns.
+	if raw == "null" {
+		return "nil"
+	}
+
 	inner := strings.TrimPrefix(f.GoType, "*")
 
 	var expr string

--- a/workshop/codegen/generators/fixture_test.go
+++ b/workshop/codegen/generators/fixture_test.go
@@ -159,6 +159,60 @@ func TestFixtureDefaultOverridesEmitted(t *testing.T) {
 	}
 }
 
+// A `null` override emits nil — the tenant_secrets_payload_check shape:
+// the generic fixture fills nullable external_ref with a Ptr value,
+// violating the CHECK's `external_ref IS NULL` branch.
+func TestFixtureDefaultNullEmitsNil(t *testing.T) {
+	resolved := &ResolvedFile{
+		Table:       &schema.TableInfo{TableName: "tenant_secrets"},
+		EntityName:  "TenantSecret",
+		EntityLower: "tenantsecret",
+		TableName:   "tenant_secrets",
+		PackageName: "tenantsecrets",
+		DomainName:  "tenancy",
+		PKColumn:    "secret_key",
+		PKGoName:    "SecretKey",
+		PKGoType:    "string",
+		AllColumns: []schema.ColumnInfo{
+			{Name: "secret_key", DBType: "varchar", GoType: "string", IsPrimaryKey: true},
+			{Name: "backend", DBType: "varchar", GoType: "string", IsEnum: true,
+				EnumValues: []string{"db", "gcp_kms", "gcp_secret_manager"}},
+			{Name: "ciphertext", DBType: "text", GoType: "*string", IsNullable: true},
+			{Name: "external_ref", DBType: "varchar", GoType: "*string", IsNullable: true},
+		},
+		FixtureDefaults: map[string]string{"external_ref": "null"},
+	}
+
+	dir := t.TempDir()
+	data := FixtureTemplateData{
+		ModulePath: "example.com/app",
+		Entities:   []FixtureEntity{BuildFixtureEntity(resolved, "example.com/app")},
+	}
+	if err := GenerateFixtures(data, dir, Options{}); err != nil {
+		t.Fatalf("GenerateFixtures: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "generated.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(out)
+
+	if strings.Contains(content, `conversion.Ptr("test_external_ref`) {
+		t.Error("generic Ptr default must not survive a null override")
+	}
+	if !strings.Contains(content, `"db"`) {
+		t.Error("backend should keep its enum default")
+	}
+	if !strings.Contains(content, `conversion.Ptr("test_ciphertext`) {
+		t.Error("ciphertext should keep its generic nullable default")
+	}
+	// The insert args line carries the nil: ..., ciphertextPtr, nil)
+	if !strings.Contains(content, "nil)") && !strings.Contains(content, "nil,") {
+		t.Error("expected nil in the insert args for external_ref")
+	}
+}
+
 // Spec-mode fixtures share BuildFixtureEntity, so overrides must carry
 // through GenerateSpecFixtures unchanged.
 func TestFixtureDefaultOverridesEmittedSpecMode(t *testing.T) {

--- a/workshop/codegen/generators/resolve.go
+++ b/workshop/codegen/generators/resolve.go
@@ -405,6 +405,19 @@ func resolveFixtureDefaults(entries []string, table *schema.TableInfo, colMap ma
 			return nil, fmt.Errorf("column %q is a foreign key — FK values come from parent fixture wiring", column)
 		}
 
+		// The bare token `null` pins a nullable column to SQL NULL — the
+		// answer to CHECK constraints requiring a column's absence (e.g.
+		// tenant_secrets_payload_check's `external_ref IS NULL` branch).
+		// Checked before the type switch so nullable columns of any type,
+		// including time, can be nulled.
+		if value == "null" {
+			if !col.IsNullable {
+				return nil, fmt.Errorf("column %q is NOT NULL — `null` overrides need a nullable column", column)
+			}
+			defaults[column] = value
+			continue
+		}
+
 		goType := strings.TrimPrefix(col.GoType, "*")
 		switch goType {
 		case "string":

--- a/workshop/codegen/generators/resolve_test.go
+++ b/workshop/codegen/generators/resolve_test.go
@@ -21,6 +21,7 @@ func fixtureDefaultsSchema() *schema.ReflectedSchema {
 		{Name: "version", DBType: "integer", GoType: "int"},
 		{Name: "weight", DBType: "double precision", GoType: "float64"},
 		{Name: "rotated_at", DBType: "timestamptz", GoType: "time.Time", GoImport: "time"},
+		{Name: "expires_at", DBType: "timestamptz", GoType: "*time.Time", GoImport: "time", IsNullable: true},
 	}
 	return &schema.ReflectedSchema{
 		SchemaName: "public",
@@ -109,6 +110,31 @@ func TestResolveFixtureDefaults_Errors(t *testing.T) {
 				t.Errorf("error %q does not mention %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// The bare token `null` pins nullable columns of any type — including time —
+// to SQL NULL; NOT NULL columns reject it. This is the answer to CHECK
+// constraints with an IS NULL branch (tenant_secrets_payload_check requires
+// external_ref IS NULL when backend='db').
+func TestResolveFixtureDefaults_Null(t *testing.T) {
+	resolved, err := resolveWithFixtureDefaults(t, "note null", "expires_at null")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, col := range []string{"note", "expires_at"} {
+		if resolved.FixtureDefaults[col] != "null" {
+			t.Errorf("FixtureDefaults[%s] = %q, want %q", col, resolved.FixtureDefaults[col], "null")
+		}
+	}
+
+	for _, entry := range []string{"kind null", "rotated_at null", "payload null"} {
+		_, err := resolveWithFixtureDefaults(t, entry)
+		if err == nil {
+			t.Errorf("expected NOT NULL rejection for %q", entry)
+		} else if !strings.Contains(err.Error(), "NOT NULL") {
+			t.Errorf("error %q for %q does not mention NOT NULL", err, entry)
+		}
 	}
 }
 

--- a/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
+++ b/workshop/documentation/docs/gopernicus/topics/code-generation/annotations.md
@@ -52,7 +52,8 @@ Before reaching for the opt-out, check whether `@fixture-default` (below) solves
 Overrides the generated test fixture's value for one column. Repeatable — one column per line. The answer to arbitrary CHECK constraints the generic fixture can't satisfy (cross-column predicates, JSON shape requirements): supply a value that does, and the generated smoke tests keep running.
 
 ```sql
--- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
+-- @fixture-default: external_ref null
+-- @fixture-default: settings {"theme":"dark"}
 -- @fixture-default: kind entity
 ```
 
@@ -65,8 +66,11 @@ Grammar: `@fixture-default: <column> <value>` — everything after the first spa
 | bool | Must be `true` or `false`, emitted verbatim |
 | int / float | Type-checked, emitted verbatim |
 | nullable (pointer) | Value wrapped in `conversion.Ptr(...)` |
+| any nullable column | The bare token `null` pins the column to SQL NULL |
 
-An unknown column, an unparseable value, or an attempt to override a primary key, foreign key, or time column is a hard generation error naming the file — fail loud, never a silently wrong fixture. FK values always come from parent fixture wiring; PKs are generated uniquely per test row.
+`null` is the answer to CHECK constraints with an `IS NULL` branch — e.g. a `backend = 'db' AND ciphertext IS NOT NULL AND external_ref IS NULL` predicate fails against the generic fixture precisely because it fills every nullable column; `@fixture-default: external_ref null` satisfies it. (A nullable string column can't carry the literal value `"null"` as a result — an acceptable trade.)
+
+An unknown column, an unparseable value, or an attempt to override a primary key, foreign key, or (non-`null`) time column is a hard generation error naming the file — fail loud, never a silently wrong fixture. FK values always come from parent fixture wiring; PKs are generated uniquely per test row.
 
 General CHECK-constraint evaluation is explicitly not the goal — author-supplied values are. If no fixed per-column value can satisfy the invariant (e.g. mutually exclusive nullable FK groups), fall back to `@skip-integration-test`.
 

--- a/workshop/documentation/docs/gopernicus/workshop/testing.md
+++ b/workshop/documentation/docs/gopernicus/workshop/testing.md
@@ -260,14 +260,14 @@ so anything you add to `testPGXOptions` flows through every generated integratio
 The escape-hatch ladder, in order:
 
 1. **Do nothing** — the generator's built-in defaults (below) satisfy NOT NULL, simple `IN (…)` CHECKs, and length caps on their own.
-2. **`@fixture-default`** — when a constraint needs a specific value the generator can't infer (an arbitrary CHECK predicate, a JSON shape requirement), pin that column's fixture value and keep the generated probes running:
+2. **`@fixture-default`** — when a constraint needs a specific value the generator can't infer (an arbitrary CHECK predicate, a JSON shape requirement, an `IS NULL` branch), pin that column's fixture value and keep the generated probes running:
 
    ```sql
-   -- @fixture-default: payload {"backend":"db","ciphertext":"dGVzdA=="}
-   -- @fixture-default: kind entity
+   -- @fixture-default: external_ref null
+   -- @fixture-default: settings {"theme":"dark"}
    ```
 
-   One column per line; see the [annotations reference](../topics/code-generation/annotations.md#fixture-default) for the grammar and per-type value handling.
+   One column per line; `null` pins a nullable column to SQL NULL. See the [annotations reference](../topics/code-generation/annotations.md#fixture-default) for the grammar and per-type value handling.
 3. **`@skip-integration-test`** — last resort, when no fixed per-column value can satisfy the invariant.
 
 Some entities have cross-column invariants no fixed fixture value can satisfy — typically CHECK constraints that pin a mutually exclusive group of nullable FKs (e.g. a `nodes` table where `kind='entity'` requires exactly one of three tier columns). Add `-- @skip-integration-test` at the top of `queries.sql` to suppress the generated probes. The next regeneration replaces `generated_test.go` with a **setup-only** version: no test functions, but the `setupTestStore()` helper stays available. Hand-write smoke tests in `store_test.go` (the bootstrap) using it directly.


### PR DESCRIPTION
## Summary

Dogfooding `@fixture-default` (#26) against its motivating case — segovia's `tenant_secrets_payload_check` — exposed a gap immediately: the CHECK's only satisfiable branch requires `external_ref IS NULL`, but the annotation had no way to express NULL. The generic fixture fills every nullable column with a `conversion.Ptr(...)` value, so no author-supplied value could satisfy the constraint and the entity stayed stuck on `@skip-integration-test`.

The bare token `null` now pins a nullable column of any type (including time) to SQL NULL:

```sql
-- @fixture-default: external_ref null
```

- Resolve: `null` short-circuits before the type switch; NOT NULL columns reject it with a hard generation error.
- Fixture: emitted as `nil` (binds NULL for both pointer and slice-backed types).
- Trade documented: a nullable string column can't carry the literal value `"null"`.

## Verification

Beyond unit tests (resolve accept/reject incl. nullable time, emitted-`nil` golden check mirroring the real tenant_secrets shape), verified **end-to-end against segovia** under a temporary `replace`: dropped `@skip-integration-test` from tenantsecrets, added `-- @fixture-default: external_ref null`, regenerated, and the restored generated probes passed against real postgres via testcontainers — the insert satisfies the CHECK with `backend='db'` (enum default), non-NULL ciphertext, NULL external_ref. The segovia experiment was fully reverted afterwards (it stays pinned to released v0.3.3 until this ships).

## Follow-up

After merge + tag, segovia's tenantsecrets makes the queries.sql change for real on the next repin, closing the findings-item-5 loop end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)