### PR TITLE
fix(cryptids): strict base64 decoding in golangjwt Verify

### DIFF
--- a/infrastructure/cryptids/golangjwt/golangjwt.go
+++ b/infrastructure/cryptids/golangjwt/golangjwt.go
@@ -81,12 +81,16 @@ func (s *Signer) Verify(tokenString string) (map[string]any, error) {
 		return nil, fmt.Errorf("golangjwt: token cannot be empty")
 	}
 
+	// WithStrictDecoding rejects non-canonical base64url segments. The
+	// lenient default ignores a final character's unused padding bits, so
+	// textually distinct tokens (e.g. signature ending 'U' vs 'X') decode
+	// to the same MAC and all verify — token malleability.
 	token, err := gojwt.Parse(tokenString, func(token *gojwt.Token) (any, error) {
 		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return s.secret, nil
-	})
+	}, gojwt.WithStrictDecoding())
 	if err != nil {
 		return nil, fmt.Errorf("golangjwt: %w", err)
 	}

--- a/infrastructure/cryptids/golangjwt/golangjwt_test.go
+++ b/infrastructure/cryptids/golangjwt/golangjwt_test.go
@@ -139,6 +139,30 @@ func TestVerify(t *testing.T) {
 			t.Fatal("expected error for tampered token")
 		}
 	})
+
+	// A 43-char base64url HS256 signature's final character carries only 4
+	// significant bits; a lenient decoder ignores its low 2 padding bits, so
+	// setting one yields a textually distinct token with the same MAC. This
+	// made the tampered-token test flaky (whenever the signature ended 'U',
+	// the 'X' replacement still verified) and is token malleability —
+	// WithStrictDecoding must reject the non-canonical encoding.
+	t.Run("padding-bit malleability rejected", func(t *testing.T) {
+		const b64url = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+		token, _ := s.Sign(map[string]any{}, time.Now().Add(time.Hour))
+		idx := strings.IndexByte(b64url, token[len(token)-1])
+		if idx < 0 {
+			t.Fatalf("last token char %q not in base64url alphabet", token[len(token)-1])
+		}
+		// Canonical encodings end with zero padding bits, so idx|1 always
+		// differs from idx and changes only padding bits.
+		mutated := token[:len(token)-1] + string(b64url[idx|1])
+		if mutated == token {
+			t.Fatal("mutation produced an identical token — encoder emitted non-canonical padding bits")
+		}
+		if _, err := s.Verify(mutated); err == nil {
+			t.Fatal("expected error for non-canonical signature encoding (padding-bit malleability)")
+		}
+	})
 }
 
 func BenchmarkSign(b *testing.B) {


### PR DESCRIPTION
## Summary

Main CI's integration job (run 27385806044, the #27 merge commit) failed on `TestVerify/tampered_token` — intermittently, and the cause is real token malleability, not just a flaky assertion.

A 43-character base64url HS256 signature's final character carries only 4 significant bits; the lenient default decoder ignores its 2 padding bits. So whenever a signature ended `'U'`, the test's `'X'` replacement (same high 4 bits, different padding bits) decoded to the **identical MAC and verified successfully** — textually distinct tokens accepted as valid. Reproduced deterministically:

```
found U-ending token after 10 tries; Verify(tampered) err = <nil>     # before
found U-ending token after 13 tries; Verify(tampered) err = golangjwt: token is malformed: could not base64 decode signature: illegal base64 data at input byte 42   # after
```

(The flake never reproduced in tight `-count` loops because `exp` has second resolution — identical re-signed tokens. ~1/16 of CI runs hit a `'U'`-ending signature.)

## Fix

`gojwt.WithStrictDecoding()` on the single `Parse` call site (the only one in the codebase). Framework-issued tokens are unaffected — the signer always emits canonical encodings; only non-canonical (malleated) tokens are rejected.

Adds a deterministic regression test that flips only the final character's padding bits (`idx|1`) and expects rejection — this is exactly the case the lenient decoder accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)