### PR TITLE
feat(cli): doctor --json — machine-readable health output

### DIFF
--- a/workshop/documentation/docs/cli/doctor.md
+++ b/workshop/documentation/docs/cli/doctor.md
@@ -8,22 +8,52 @@ Check project health and configuration.
 verify that it is correctly configured for gopernicus. It is a quick way to
 identify missing files, version mismatches, or dependency problems.
 
-The command exits cleanly even when checks fail -- it prints results and
-suggestions rather than returning errors.
+The command exits non-zero when any check fails (warnings don't fail), so it
+is safe to gate scripts on it.
 
 ## Usage
 
 ```
-gopernicus doctor
+gopernicus doctor [--json]
 ```
 
-No flags or arguments. Run it from anywhere inside a gopernicus project
-directory (or a subdirectory). The command walks up the directory tree to find
-the project root by locating `go.mod`.
+Run it from anywhere inside a gopernicus project directory (or a
+subdirectory). The command walks up the directory tree to find the project
+root by locating `go.mod`.
+
+### `--json`
+
+Emits the run as machine-readable JSON on stdout instead of the human
+report. Field names are a stable contract for agents and scripts:
+
+```json
+{
+  "root": "/home/user/code/myapp",
+  "framework": "v0.4.0",
+  "ok": false,
+  "checks": [
+    {"name": "go.mod", "passed": true},
+    {"name": "sql: Pred.Raw usage", "passed": true, "warn": true, "detail": "store.go:12 raw predicate"},
+    {"name": "gopernicus framework", "passed": false, "detail": "not found in go.mod"}
+  ]
+}
+```
+
+- `ok` is false when any check is a hard failure; warnings (`"warn": true`)
+  never fail the run.
+- `framework` is the project's pinned framework version from go.mod; omitted
+  when no version-shaped pin is found.
+- `detail` and `warn` are omitted when empty/false.
+- Exit code matches the human mode (non-zero on failure), and error text
+  goes to stderr — stdout is always exactly one JSON object:
+
+```bash
+go tool gopernicus doctor --json | jq -e '.ok'
+```
 
 ## Checks Performed
 
-Doctor runs five checks in order:
+Doctor runs these checks in order:
 
 ### 1. go.mod
 
@@ -70,6 +100,23 @@ Scans `go.mod` for a `require` or `replace` line referencing
   dependencies.
 - **Fail**: "not found in go.mod" -- run
   `go get github.com/gopernicus/gopernicus@latest` to add it.
+
+### 6. SQL guards
+
+Scans store packages for SQL-injection hazards via the standing guard.
+
+- **Pass**: "sql: parameterized queries" -- no unsanctioned dynamic
+  concatenation into SQL.
+- **Fail**: names the first offending position (e.g. a `fmt.Sprintf` built
+  into a query) -- use placeholders (`args.Add`) or `QuoteIdent`.
+- **Warning**: "sql: Pred.Raw usage" -- `Pred.Raw` is a legitimate escape
+  hatch that deserves review on every run; it never fails the run.
+
+### 7. Bridge body limits
+
+Walks `bridge.yml` files and warns when a write route (Create/Update) has no
+`max_body_size` middleware -- unbounded request bodies are a
+resource-exhaustion vector. A warning, not a failure.
 
 ## Output Format
 

--- a/workshop/gopernicus/commands/doctor.go
+++ b/workshop/gopernicus/commands/doctor.go
@@ -3,11 +3,14 @@ package commands
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/gopernicus/gopernicus/workshop/codegen/cli"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+
+	"github.com/gopernicus/gopernicus/workshop/codegen/cli"
 
 	"github.com/gopernicus/gopernicus/workshop/codegen/generators"
 	"github.com/gopernicus/gopernicus/workshop/codegen/goversion"
@@ -28,7 +31,7 @@ Verifies:
   - gopernicus.yml manifest exists and is valid
   - Workshop directory exists
   - Gopernicus framework is in go.mod dependencies`,
-		Usage: "gopernicus doctor",
+		Usage: "gopernicus doctor [--json]",
 		Run:   runDoctor,
 	})
 }
@@ -40,47 +43,121 @@ type check struct {
 	warn   bool // warning, not failure
 }
 
-func runDoctor(_ context.Context, _ []string) error {
+// doctorResult is the machine-readable shape of a doctor run. Field names
+// are a stable contract — agents and scripts parse this output.
+type doctorResult struct {
+	Root      string        `json:"root"`
+	Framework string        `json:"framework,omitempty"`
+	OK        bool          `json:"ok"`
+	Checks    []doctorCheck `json:"checks"`
+}
+
+type doctorCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Warn   bool   `json:"warn,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func runDoctor(_ context.Context, args []string) error {
+	asJSON := hasFlag(args, "--json")
+
 	root, err := project.FindRoot()
 	if err != nil {
-		fmt.Println("✗ project root — no go.mod found in current or parent directories")
+		rootCheck := check{name: "project root", passed: false, detail: "no go.mod found in current or parent directories"}
+		if asJSON {
+			printDoctorJSON(buildDoctorResult("", "", []check{rootCheck}))
+		} else {
+			fmt.Println("✗ project root — no go.mod found in current or parent directories")
+		}
 		return fmt.Errorf("doctor found problems")
 	}
-	fmt.Printf("  project root: %s\n\n", root)
 
+	frameworkCheck, frameworkVersion := checkFrameworkDep(root)
 	checks := []check{
 		checkGoMod(root),
 		checkGoVersion(root),
 		checkManifest(root),
 		checkWorkshopDir(root),
-		checkFrameworkDep(root),
+		frameworkCheck,
 	}
 	checks = append(checks, checkSQLGuards(root)...)
 	checks = append(checks, checkBodyLimits(root))
 
-	allPassed := true
+	result := buildDoctorResult(root, frameworkVersion, checks)
+
+	if asJSON {
+		printDoctorJSON(result)
+	} else {
+		printDoctorHuman(result)
+	}
+
+	if !result.OK {
+		return fmt.Errorf("doctor found problems")
+	}
+	return nil
+}
+
+// buildDoctorResult folds raw checks into the stable result shape. A run is
+// OK when no check is a hard failure (warnings don't fail).
+func buildDoctorResult(root, frameworkVersion string, checks []check) doctorResult {
+	result := doctorResult{
+		Root:      root,
+		Framework: frameworkVersion,
+		OK:        true,
+		Checks:    make([]doctorCheck, 0, len(checks)),
+	}
 	for _, c := range checks {
-		symbol := "✓"
 		if !c.passed && !c.warn {
+			result.OK = false
+		}
+		result.Checks = append(result.Checks, doctorCheck{
+			Name:   c.name,
+			Passed: c.passed,
+			Warn:   c.warn,
+			Detail: c.detail,
+		})
+	}
+	return result
+}
+
+func printDoctorHuman(result doctorResult) {
+	fmt.Printf("  project root: %s\n\n", result.Root)
+
+	for _, c := range result.Checks {
+		symbol := "✓"
+		if !c.Passed && !c.Warn {
 			symbol = "✗"
-			allPassed = false
-		} else if c.warn {
+		} else if c.Warn {
 			symbol = "!"
 		}
-		line := fmt.Sprintf("%s %s", symbol, c.name)
-		if c.detail != "" {
-			line += fmt.Sprintf(" — %s", c.detail)
+		line := fmt.Sprintf("%s %s", symbol, c.Name)
+		if c.Detail != "" {
+			line += fmt.Sprintf(" — %s", c.Detail)
 		}
 		fmt.Println(line)
 	}
 
 	fmt.Println()
-	if !allPassed {
+	if !result.OK {
 		fmt.Println("Some checks failed. Run 'gopernicus init' to set up a project.")
-		return fmt.Errorf("doctor found problems")
+		return
 	}
 	fmt.Println("All checks passed.")
-	return nil
+}
+
+func printDoctorJSON(result doctorResult) {
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Printf(`{"root":%q,"ok":false,"checks":[{"name":"json encoding","passed":false,"detail":%q}]}`+"\n", result.Root, err.Error())
+		return
+	}
+	fmt.Println(string(out))
+}
+
+// hasFlag reports whether a bare boolean flag is present in args.
+func hasFlag(args []string, flag string) bool {
+	return slices.Contains(args, flag)
 }
 
 func checkGoMod(root string) check {
@@ -209,10 +286,13 @@ func checkBodyLimits(root string) check {
 	return check{name: "bridge: write routes bound body size", passed: true, warn: true, detail: detail}
 }
 
-func checkFrameworkDep(root string) check {
+// checkFrameworkDep verifies the framework pin in go.mod and also returns
+// the pinned version string ("" when absent) for the doctor result's
+// top-level framework field.
+func checkFrameworkDep(root string) (check, string) {
 	f, err := os.Open(filepath.Join(root, "go.mod"))
 	if err != nil {
-		return check{name: "gopernicus dependency", passed: false, detail: "could not read go.mod"}
+		return check{name: "gopernicus dependency", passed: false, detail: "could not read go.mod"}, ""
 	}
 	defer f.Close()
 
@@ -220,17 +300,25 @@ func checkFrameworkDep(root string) check {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if strings.Contains(line, generators.FrameworkModulePath) {
-			// Extract version from the require line.
+			// Extract version from the require line. In the framework repo
+			// itself the match is the module declaration, so the trailing
+			// token is the module path — only report version-shaped tokens
+			// in the result's framework field.
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
-				return check{name: fmt.Sprintf("gopernicus framework (%s)", parts[len(parts)-1]), passed: true}
+				token := parts[len(parts)-1]
+				version := ""
+				if strings.HasPrefix(token, "v") {
+					version = token
+				}
+				return check{name: fmt.Sprintf("gopernicus framework (%s)", token), passed: true}, version
 			}
-			return check{name: "gopernicus framework", passed: true}
+			return check{name: "gopernicus framework", passed: true}, ""
 		}
 	}
 	return check{
 		name:   "gopernicus framework",
 		passed: false,
 		detail: "not found in go.mod — run 'go get " + generators.FrameworkModulePath + "@latest'",
-	}
+	}, ""
 }

--- a/workshop/gopernicus/commands/doctor_test.go
+++ b/workshop/gopernicus/commands/doctor_test.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The JSON field names are a stable contract — agents and scripts parse
+// doctor --json output. These tests pin the shape.
+func TestBuildDoctorResult(t *testing.T) {
+	checks := []check{
+		{name: "go.mod", passed: true},
+		{name: "sql: Pred.Raw usage", passed: true, warn: true, detail: "store.go:12 raw predicate"},
+		{name: "gopernicus framework", passed: false, detail: "not found in go.mod"},
+	}
+	result := buildDoctorResult("/proj", "v0.4.0", checks)
+
+	if result.OK {
+		t.Error("a hard failure must set ok=false")
+	}
+	if result.Root != "/proj" || result.Framework != "v0.4.0" {
+		t.Errorf("root/framework = %q/%q", result.Root, result.Framework)
+	}
+	if len(result.Checks) != 3 {
+		t.Fatalf("checks = %d, want 3", len(result.Checks))
+	}
+	if !result.Checks[1].Warn || !result.Checks[1].Passed {
+		t.Error("warn check must carry warn=true and passed=true")
+	}
+}
+
+func TestBuildDoctorResult_WarningsDoNotFail(t *testing.T) {
+	result := buildDoctorResult("/proj", "", []check{
+		{name: "a", passed: true},
+		{name: "b", passed: true, warn: true, detail: "advisory"},
+	})
+	if !result.OK {
+		t.Error("warnings alone must not set ok=false")
+	}
+}
+
+func TestDoctorResultJSONShape(t *testing.T) {
+	result := buildDoctorResult("/proj", "v0.4.0", []check{
+		{name: "go.mod", passed: true},
+		{name: "broken", passed: false, detail: "why"},
+	})
+	out, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"root", "framework", "ok", "checks"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("JSON output missing stable key %q", key)
+		}
+	}
+	checks, ok := decoded["checks"].([]any)
+	if !ok || len(checks) != 2 {
+		t.Fatalf("checks = %v", decoded["checks"])
+	}
+	first, ok := checks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("check[0] = %v", checks[0])
+	}
+	for _, key := range []string{"name", "passed"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("check object missing stable key %q", key)
+		}
+	}
+	// Empty-detail and warn=false omit their keys — keep payloads tight.
+	if _, present := first["detail"]; present {
+		t.Error("empty detail must be omitted")
+	}
+	if _, present := first["warn"]; present {
+		t.Error("warn=false must be omitted")
+	}
+}
+
+func TestHasFlag(t *testing.T) {
+	if !hasFlag([]string{"--json"}, "--json") {
+		t.Error("expected --json detected")
+	}
+	if hasFlag([]string{"--jsonx", "tenancy"}, "--json") {
+		t.Error("prefix must not match")
+	}
+}


### PR DESCRIPTION
## Summary

First item of the ratified v0.4 plan (`.claude/roadmap/plan-v0.4-trustworthy-lifecycle.md`): `doctor --json` emits a stable machine-readable shape so agents and scripts can gate on project health.

```json
{
  "root": "/path/to/project",
  "framework": "v0.3.5",
  "ok": true,
  "checks": [{"name": "go.mod", "passed": true}, ...]
}
```

- `runDoctor` split into collect + render; **human output is byte-identical** to before.
- `ok` is false only on hard failures — warnings (`warn: true`) never fail, matching existing exit semantics.
- `framework` carries the project's pin from go.mod, only when version-shaped (in the framework repo itself the go.mod match is the `module` line — the human check keeps its pre-existing behavior, the JSON field is just omitted).
- Errors go to stderr; stdout is always exactly one JSON object. `doctor --json | jq -e '.ok'` works.
- The no-project path also emits JSON (`{"root": "", "ok": false, ...}`) with exit 1.

## Verification (real projects, not just unit tests)

| Project | Result |
|---|---|
| framework repo | `ok: true`, framework field omitted, human output unchanged |
| segovia | `ok: true`, `framework: v0.3.5`, 7 checks |
| loremanac | `ok: false` via its pre-existing sqlguard finding — failure shape confirmed |
| no project (cwd /tmp) | JSON error object + exit 1 |

Unit tests pin the JSON contract (stable keys, omitempty behavior, warn-doesn't-fail).

Docs: cli/doctor.md gains the `--json` section and catches up with reality — it claimed doctor "exits cleanly even when checks fail" and documented only 5 of the 7 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)