### PR TITLE
docs: CHANGELOG with consumer-action checklists + upgrading guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,160 @@
+# Changelog
+
+All notable changes to the gopernicus framework, with a **Consumer actions**
+checklist per release. The checklists are written as imperative steps so a
+human or agent can execute them top to bottom; the generic repin flow they
+assume is documented in
+[the upgrading guide](workshop/documentation/docs/guides/upgrading.md).
+
+Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
+
+## Unreleased
+
+### Added
+- `gopernicus doctor --json` — machine-readable health output with a stable
+  field contract (`root`, `framework`, `ok`, `checks[]`). Exit codes and the
+  human report are unchanged. (#30)
+
+### Consumer actions
+- [ ] None required. Scripts may now gate on
+      `go tool gopernicus doctor --json | jq -e '.ok'`.
+
+## v0.3.5 — 2026-06-11
+
+### Fixed
+- `infrastructure/cryptids/golangjwt`: `Verify` now uses strict base64
+  decoding, rejecting non-canonical token encodings. Previously, textually
+  distinct tokens differing only in a final character's padding bits decoded
+  to the same MAC and all verified (token malleability). Framework-issued
+  tokens are unaffected — the signer always emits canonical encodings. (#28)
+
+### Consumer actions
+- [ ] Repin: `go get github.com/gopernicus/gopernicus@v0.3.5 && go mod tidy`
+      (+ `go mod vendor` if vendored), regenerate, run the verification gate.
+- [ ] Redeploy to pick up the verify-path change. No code changes; existing
+      sessions remain valid (their tokens are canonical).
+- [ ] If anything keys on raw token strings (blocklists, caches), note that
+      malleated variants are now rejected rather than accepted.
+
+## v0.3.4 — 2026-06-11
+
+### Added
+- `@fixture-default` accepts the bare token `null` to pin a nullable column
+  (any type) to SQL NULL — the answer to CHECK constraints with an
+  `IS NULL` branch. Rejected on NOT NULL columns at generation time. (#27)
+
+### Consumer actions
+- [ ] Repin to v0.3.4, regenerate, run the verification gate.
+- [ ] For entities skipped over CHECK constraints requiring a column's
+      absence: replace `-- @skip-integration-test` with
+      `-- @fixture-default: <column> null` and regenerate — the generated
+      integration probes come back.
+
+## v0.3.3 — 2026-06-11
+
+### Added
+- CI gates on the framework repo: build/vet/unit, tagged-compile
+  (`integration`/`e2e`/`penetration` vet), clean-regenerate (drift check),
+  and the integration suite. (#25)
+- `@fixture-default: <column> <value>` — file-level, repeatable queries.sql
+  annotation overriding the generated test fixture's value for one column.
+  Validated against the reflected schema; PK/FK/time overrides and
+  unparseable values are hard generation errors. Positioned before
+  `@skip-integration-test` on the escape-hatch ladder. (#26)
+
+### Changed
+- go.mod `go` directive aligned to `goversion.MinGoVersion` (1.26). The two
+  move in lockstep from here on.
+
+### Consumer actions
+- [ ] Ensure a Go ≥ 1.26 toolchain, then repin to v0.3.3, regenerate, run
+      the verification gate.
+- [ ] Optional: adopt `@fixture-default` for entities whose CHECK
+      constraints the generic fixture can't satisfy.
+
+## v0.3.2 — 2026-06-11
+
+### Added
+- Invitations bridge: `redirect_url` on the create request with a
+  `WithAllowedFrontends` allowlist (strict when configured, pass-through
+  when not), and `WithEmailer` / resolver options for email subscribers. (#24)
+
+### Changed
+- `@skip-integration-test` now regenerates `generated_test.go` as a
+  **setup-only** file (no test functions, `setupTestStore` helper kept)
+  instead of removing it. (#24)
+
+### Consumer actions
+- [ ] Repin to v0.3.2, regenerate, run the verification gate.
+- [ ] If a skipped entity's `store_test.go` carries a private copy of
+      `setupTestStore`, delete the copy — the regenerated setup-only file
+      reintroduces the helper and the package otherwise fails to compile
+      with a duplicate symbol.
+- [ ] If using the invitations bridge: configure `WithAllowedFrontends`
+      for strict redirect validation and `WithEmailer` if invitation email
+      delivery is wanted.
+
+## v0.3.1 — 2026-06-11
+
+Fixes for everything the first real consumer migration (segovia → v0.3.0)
+surfaced. (#23)
+
+### Added
+- Shipped oauthaccounts spec gains `GetByProvider`, `ListByUser`,
+  `DeleteByUserAndProvider`.
+- Bridge e2e generation prints a per-bridge skip reason instead of emitting
+  nothing silently.
+- Scaffolded Makefiles gain gopernicus targets.
+
+### Fixed
+- Shipped serviceaccounts `GetPrincipalInfo` wraps
+  `COALESCE(owner_user_id, '')` — the bare nullable select failed row scans.
+- Integration-test emitter: only a method literally named `Get` drives
+  Get-roundtrip probes; unusable probes regenerate setup-only with a printed
+  reason; scope args reading fixture-NULL self-referential FK columns
+  suppress the probe needing them.
+- Principal-inheritance fixtures insert a CHECK-valid `principal_type`.
+
+### Consumer actions
+- [ ] Repin to v0.3.1, regenerate, run the verification gate.
+- [ ] If oauthaccounts or serviceaccounts specs were ejected to work around
+      the above: delete the project-local queries.sql to re-adopt the fixed
+      shipped specs, regenerate, diff.
+
+## v0.3.0 — 2026-06-10
+
+The generator ships in-framework. The standalone gopernicus-cli repo is
+archived.
+
+### Added
+- Bootstrap via `go run github.com/gopernicus/gopernicus/workshop/gopernicus@latest init`;
+  projects pin the generator with go.mod's `tool` directive
+  (`go tool gopernicus <cmd>`).
+- Satisfiers are generated (existing headerless copies are skipped, never
+  overwritten).
+- Feature entity queries.sql ship with the framework; a project-local file
+  is an ejection that wins over the shipped spec.
+- Bridge e2e tests emit next to each bridge with `testserver.ServeBridge`
+  wiring (the old `workshop/testing/e2e/` layout is retired).
+
+### Changed
+- Invitations engine is self-contained: `NewInviter` takes
+  `invitations.InvitationRepository` and speaks engine types — breaking for
+  consumers that wired an Inviter against repository types.
+- Legacy manifest shape and the `@database:` annotation are retired.
+
+### Consumer actions
+- [ ] Follow the full migration: this is the large one. The phase sequence
+      (unbreak build → adopt pinned tool → regenerate and reconcile by file
+      class → satisfier adoption → spec-ejection policy → verification
+      gate) is the upgrading guide's long-form example.
+
+## v0.2.0 — 2026-06-10
+
+- The generator becomes a versioned artifact of the framework (codegen
+  lifted into `workshop/codegen`, import-engines work, generation v2
+  phase 0).
+
+## Earlier (≤ v0.1.8)
+
+Pre-changelog history; see git tags v0.0.x–v0.1.8.

--- a/workshop/documentation/docs/guides/upgrading.md
+++ b/workshop/documentation/docs/guides/upgrading.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 5
+title: Upgrading the Framework
+---
+
+# Upgrading the Framework
+
+How to move a gopernicus project to a newer framework version. The flow is
+the same for every release; per-release specifics live in the
+[CHANGELOG](https://github.com/gopernicus/gopernicus/blob/main/CHANGELOG.md)
+as a **Consumer actions** checklist — read that release's entry (and every
+entry between your pin and the target) before starting.
+
+The framework pins the generator to the runtime via go.mod's `tool`
+directive, so repinning upgrades both together — generated code and
+framework can never drift apart.
+
+---
+
+## The repin flow
+
+### 1. Repin
+
+```bash
+go get github.com/gopernicus/gopernicus@vX.Y.Z
+go mod tidy
+go mod vendor   # only if your project vendors dependencies
+```
+
+If your go.mod carries a `replace` pointing at a local framework checkout,
+drop it first (`go mod edit -dropreplace=github.com/gopernicus/gopernicus`).
+Keep a replace only while actively co-developing the framework.
+
+### 2. Regenerate
+
+```bash
+go tool gopernicus generate
+```
+
+If a release changed schema reflection, run `go tool gopernicus db reflect`
+first (the CHANGELOG entry will say so).
+
+### 3. Reconcile the diff, file class by file class
+
+Review `git diff` grouped by what gopernicus owns:
+
+| File class | What to expect |
+|---|---|
+| `generated*.go` | Regenerated wholesale — review for surprises, don't hand-edit |
+| Bootstrap files (`repository.go`, `store.go`, `bridge.go`, `fixtures.go`, `store_test.go`, …) | Untouched except marker blocks (e.g. the Storer interface between `// gopernicus:start` markers) — your custom code above markers survives |
+| Satisfiers | Generated when headers present; headerless copies are skipped with a printed note |
+| Generation output notes | Read them — skips and "left untouched" notes are deliberate signals, not noise |
+
+### 4. Apply the release's consumer actions
+
+Work through the CHANGELOG checklist for every release between your old pin
+and the new one, oldest first. Typical actions: dropping a spec ejection to
+re-adopt a fixed shipped spec, deleting a private helper copy a regenerated
+file now provides, or adopting a new annotation.
+
+### 5. Verification gate
+
+```bash
+go build ./... && go vet ./... && go test ./...
+go test -tags=integration ./...   # database up
+go test -tags=e2e ./...
+go tool gopernicus doctor
+```
+
+Then the determinism check — regenerate twice and confirm a clean tree:
+
+```bash
+go tool gopernicus generate && go tool gopernicus generate
+git status   # generated files must show no further changes
+```
+
+Finally, boot the app and smoke one auth flow plus one custom-domain
+endpoint. Green tests alone are not a release gate.
+
+---
+
+## Refreshing bootstrap files
+
+Bootstrap files are created once and never overwritten, so a project
+carries them at the template vintage of whatever version first generated
+them. When a release improves a bootstrap template:
+
+- `go tool gopernicus generate --force-bootstrap` overwrites **all**
+  bootstrap files. Never run this blindly on a project with customized
+  bootstraps — diff first, or refresh selectively by deleting the specific
+  file and regenerating.
+- The safest selective refresh: `git rm` the one file, regenerate (it comes
+  back at the current template), then re-apply your customizations from
+  git history.
+
+## Spec ejection policy
+
+Feature entities (auth, rebac, tenancy, events, jobs) have shipped specs;
+a project-local `queries.sql` for one of them is an **ejection** that wins
+over the shipped spec — and forfeits upstream spec improvements.
+
+On each upgrade, for every ejected feature entity, diff your file against
+the framework's `core/repositories/<domain>/<entity>/queries.sql` at the
+new tag:
+
+- **Identical** → delete your file to adopt the shipped spec (automatic
+  updates on future bumps).
+- **Different** → keep it, and document why at the top of the file.
+
+Re-ejecting is always possible: create the file again and it wins.
+
+## Version skew rules
+
+- Upgrade one consumer project at a time; the framework supports being on
+  different pins across projects indefinitely.
+- Don't skip reading intermediate CHANGELOG entries — consumer actions
+  compound.
+- `go tool gopernicus doctor` after every upgrade; `doctor --json` if a
+  script or agent is driving.

--- a/workshop/documentation/sidebars.ts
+++ b/workshop/documentation/sidebars.ts
@@ -194,6 +194,7 @@ const sidebars: SidebarsConfig = {
         "guides/adding-use-case",
         "guides/adding-auth-to-entity",
         "guides/adding-adapter",
+        "guides/upgrading",
       ],
     },
     "roadmap/roadmap",


### PR DESCRIPTION
## Summary

v0.4 plan item 2 — the upgrade story as docs, no new CLI surface.

**CHANGELOG.md** (repo root): backfilled v0.2.0 → v0.3.5 plus Unreleased (#30). Each release has a `### Consumer actions` subsection written as `- [ ]` imperative steps — executable by a human or agent, oldest-first across skipped versions. Sourced from the actual v0.3.x release train and the segovia migration findings, so the checklists describe what consumers really had to do (e.g. v0.3.2's duplicate-`setupTestStore` cleanup, v0.3.1's ejection re-adoption).

**docs/guides/upgrading.md**: the generic repin flow distilled from the hand-walked v0.3.0 migration — repin → regenerate → reconcile diff by file class → apply release checklists → verification gate (generate-twice determinism check, real-app smoke). Documents the bootstrap-refresh options (never blanket `--force-bootstrap` on customized bootstraps; selective refresh via git rm + regenerate) and the per-upgrade spec-ejection diff policy.

Per the ratified plan, a `gopernicus upgrade` command is an explicit non-goal until this checklist format survives two releases.

## Verification
- Docusaurus build passes; new page renders in the Guides sidebar. The build's broken-link warnings are all pre-existing (none involve the new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)