### PR TITLE
feat(codegen): bootstrap template-drift detection — markers + doctor check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,18 @@ Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 - `gopernicus doctor --json` — machine-readable health output with a stable
   field contract (`root`, `framework`, `ok`, `checks[]`). Exit codes and the
   human report are unchanged. (#30)
+- Bootstrap drift detection: newly created bootstrap files carry a
+  first-line marker (`// gopernicus:bootstrap kind=... template=<hash>`)
+  recording the creating template's content hash; a new doctor check warns
+  when a file's template has since changed. The hash covers the template,
+  never the file — your edits to bootstraps don't count as drift.
 
 ### Consumer actions
 - [ ] None required. Scripts may now gate on
       `go tool gopernicus doctor --json | jq -e '.ok'`.
+- [ ] Existing bootstrap files have no markers and are reported as a
+      pre-marker count, not warnings; they start tracking when refreshed
+      or newly created.
 
 ## v0.3.5 — 2026-06-11
 

--- a/workshop/codegen/generators/authschema.go
+++ b/workshop/codegen/generators/authschema.go
@@ -65,6 +65,10 @@ func GenerateAuthSchema(domainDir, domainPkg, modulePath string, resolvedFiles [
 			return fmt.Errorf("render %s for %s: %w", f.name, domainPkg, err)
 		}
 
+		if f.bootstrap {
+			out = prependBootstrapMarker("authschema/"+f.name, out)
+		}
+
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
 			return err
 		}

--- a/workshop/codegen/generators/bootstrap_registry.go
+++ b/workshop/codegen/generators/bootstrap_registry.go
@@ -1,0 +1,97 @@
+package generators
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// bootstrapMarkerPrefix opens the marker line written as the first line of
+// every bootstrap file at creation time. The marker records which template
+// (by content hash) created the file, so doctor can detect when a project
+// carries a bootstrap from an older template vintage. The hash covers the
+// TEMPLATE, not the rendered file — user edits to bootstraps are expected
+// and never count as drift.
+const bootstrapMarkerPrefix = "// gopernicus:bootstrap "
+
+// bootstrapTemplates is the registry of every bootstrap kind the generators
+// emit, mapping kind → the template constant that renders it. Kind names
+// are `<generator>/<file>` and are part of the marker contract — renaming
+// one orphans existing markers. A new bootstrap genFile entry MUST be
+// registered here: bootstrapMarker panics on unknown kinds so generation
+// fails loud, never silently unmarked.
+var bootstrapTemplates = map[string]string{
+	"repository/repository.go":         repoRepositoryTemplate,
+	"repository/fop.go":                repoFopTemplate,
+	"pgxstore/store.go":                storeBootstrapTemplate,
+	"specstore/store.go":               specStoreBootstrapTemplate,
+	"bridge/bridge.go":                 bridgeBridgeTemplate,
+	"bridge/routes.go":                 bridgeRoutesTemplate,
+	"bridge/http.go":                   bridgeHttpTemplate,
+	"bridge/fop.go":                    bridgeFopTemplate,
+	"authschema/authschema.go":         authSchemaBootstrapTemplate,
+	"cache/cache.go":                   cacheBootstrapTemplate,
+	"fixtures/fixtures.go":             fixtureBootstrapTemplate,
+	"integrationtest/store_test.go":    integrationTestBootstrapTemplate,
+	"bridge-e2e/e2e_test.go":           bridgeE2EBootstrapTemplate,
+	"bridge-security/security_test.go": bridgeSecurityBootstrapTemplate,
+}
+
+// BootstrapTemplateHash returns the content hash of the registered template
+// for kind, and whether the kind is known to this framework version.
+func BootstrapTemplateHash(kind string) (string, bool) {
+	tmpl, ok := bootstrapTemplates[kind]
+	if !ok {
+		return "", false
+	}
+	return hashTemplate(tmpl), true
+}
+
+// BootstrapBasenames returns the set of file basenames that are bootstrap
+// files by convention — used by doctor to count pre-marker bootstraps.
+func BootstrapBasenames() map[string]bool {
+	names := make(map[string]bool, len(bootstrapTemplates))
+	for kind := range bootstrapTemplates {
+		if i := strings.IndexByte(kind, '/'); i >= 0 {
+			names[kind[i+1:]] = true
+		}
+	}
+	return names
+}
+
+// ParseBootstrapMarker parses a bootstrap marker line into its kind and
+// template hash. ok is false when the line is not a marker.
+func ParseBootstrapMarker(line string) (kind, hash string, ok bool) {
+	rest, found := strings.CutPrefix(strings.TrimSpace(line), bootstrapMarkerPrefix)
+	if !found {
+		return "", "", false
+	}
+	for _, field := range strings.Fields(rest) {
+		if v, found := strings.CutPrefix(field, "kind="); found {
+			kind = v
+		}
+		if v, found := strings.CutPrefix(field, "template="); found {
+			hash = v
+		}
+	}
+	return kind, hash, kind != "" && hash != ""
+}
+
+// prependBootstrapMarker prefixes rendered bootstrap output with its marker
+// line. Panics on an unregistered kind: a bootstrap file written without a
+// marker would be invisible to drift detection forever, so generation must
+// fail loud at develop time, not ship silently unmarked.
+func prependBootstrapMarker(kind string, rendered []byte) []byte {
+	tmpl, ok := bootstrapTemplates[kind]
+	if !ok {
+		panic(fmt.Sprintf("generators: bootstrap kind %q not in bootstrapTemplates — register it in bootstrap_registry.go", kind))
+	}
+	marker := fmt.Sprintf("%skind=%s template=%s\n", bootstrapMarkerPrefix, kind, hashTemplate(tmpl))
+	return append([]byte(marker), rendered...)
+}
+
+func hashTemplate(tmpl string) string {
+	sum := sha256.Sum256([]byte(tmpl))
+	return hex.EncodeToString(sum[:])[:12]
+}

--- a/workshop/codegen/generators/bootstrap_registry_test.go
+++ b/workshop/codegen/generators/bootstrap_registry_test.go
@@ -1,0 +1,100 @@
+package generators
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapRegistry(t *testing.T) {
+	if len(bootstrapTemplates) == 0 {
+		t.Fatal("registry is empty")
+	}
+	hashes := make(map[string]string)
+	for kind, tmpl := range bootstrapTemplates {
+		if tmpl == "" {
+			t.Errorf("kind %q has an empty template", kind)
+		}
+		if !strings.Contains(kind, "/") {
+			t.Errorf("kind %q must be <generator>/<file>", kind)
+		}
+		h, ok := BootstrapTemplateHash(kind)
+		if !ok || len(h) != 12 {
+			t.Errorf("BootstrapTemplateHash(%q) = %q, %v", kind, h, ok)
+		}
+		hashes[kind] = h
+	}
+	if _, ok := BootstrapTemplateHash("nope/nope.go"); ok {
+		t.Error("unknown kind must not resolve")
+	}
+}
+
+func TestBootstrapMarkerRoundTrip(t *testing.T) {
+	out := prependBootstrapMarker("repository/repository.go", []byte("package x\n"))
+	firstLine, _, _ := strings.Cut(string(out), "\n")
+
+	kind, hash, ok := ParseBootstrapMarker(firstLine)
+	if !ok {
+		t.Fatalf("marker line did not parse: %q", firstLine)
+	}
+	if kind != "repository/repository.go" {
+		t.Errorf("kind = %q", kind)
+	}
+	want, _ := BootstrapTemplateHash(kind)
+	if hash != want {
+		t.Errorf("hash = %q, want %q", hash, want)
+	}
+
+	if _, _, ok := ParseBootstrapMarker("// just a comment"); ok {
+		t.Error("non-marker line must not parse")
+	}
+}
+
+func TestPrependBootstrapMarkerPanicsOnUnknownKind(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for unregistered kind — unmarked bootstraps must fail loud")
+		}
+	}()
+	prependBootstrapMarker("unregistered/file.go", []byte("package x\n"))
+}
+
+// Generated bootstrap files must carry the marker as their first line and
+// still survive gofmt — verified through a real generator (fixtures).
+func TestGeneratedBootstrapCarriesMarker(t *testing.T) {
+	dir := t.TempDir()
+	data := FixtureTemplateData{
+		ModulePath: "example.com/app",
+		Entities:   []FixtureEntity{BuildFixtureEntity(principalsFixtureResolved(), "example.com/app")},
+	}
+	if err := GenerateFixtures(data, dir, Options{}); err != nil {
+		t.Fatalf("GenerateFixtures: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "fixtures.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstLine, _, _ := strings.Cut(string(out), "\n")
+	kind, hash, ok := ParseBootstrapMarker(firstLine)
+	if !ok {
+		t.Fatalf("fixtures.go first line is not a marker: %q", firstLine)
+	}
+	if kind != "fixtures/fixtures.go" {
+		t.Errorf("kind = %q", kind)
+	}
+	if want, _ := BootstrapTemplateHash(kind); hash != want {
+		t.Errorf("hash = %q, want %q", hash, want)
+	}
+
+	// The generated (non-bootstrap) file must NOT carry a marker.
+	gen, err := os.ReadFile(filepath.Join(dir, "generated.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	genFirst, _, _ := strings.Cut(string(gen), "\n")
+	if _, _, ok := ParseBootstrapMarker(genFirst); ok {
+		t.Error("generated.go must not carry a bootstrap marker")
+	}
+}

--- a/workshop/codegen/generators/bridge.go
+++ b/workshop/codegen/generators/bridge.go
@@ -96,6 +96,10 @@ func GenerateBridge(resolved *ResolvedFile, domainName, modulePath, projectRoot 
 			return false, fmt.Errorf("render %s for %s: %w", f.name, resolved.TableName, err)
 		}
 
+		if f.bootstrap {
+			out = prependBootstrapMarker("bridge/"+f.name, out)
+		}
+
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
 			return false, err
 		}

--- a/workshop/codegen/generators/bridge_e2e_gen.go
+++ b/workshop/codegen/generators/bridge_e2e_gen.go
@@ -65,10 +65,10 @@ type BridgeE2EData struct {
 	// Update-path mass-assignment probe (P5): a PUT setting a legit field
 	// plus a smuggled record_state must leave the stored state untouched.
 	// Requires record_state, an Update route, and a settable update field.
-	HasUpdate         bool
-	UpdatePathExpr    string // Go expr building the PUT path from `id`
-	UpdateLegitJSON   string // a non-server-set update field (json name)
-	UpdateLegitValue  string // a valid value literal for that field
+	HasUpdate        bool
+	UpdatePathExpr   string // Go expr building the PUT path from `id`
+	UpdateLegitJSON  string // a non-server-set update field (json name)
+	UpdateLegitValue string // a valid value literal for that field
 
 	// String filter params (plus "search") get the strict probe: a payload
 	// is a parameterized match value, so a 200 must return zero rows.
@@ -99,14 +99,14 @@ func GenerateBridgeE2E(data BridgeTemplateData, resolved *ResolvedFile, bridgeDi
 		return nil
 	}
 
-	if err := renderE2EFile(path, bridgeE2EGeneratedTemplate, e2e, opts); err != nil {
+	if err := renderE2EFile(path, bridgeE2EGeneratedTemplate, "", e2e, opts); err != nil {
 		return err
 	}
 	fmt.Printf("      write %s\n", path)
 
 	bootstrapPath := filepath.Join(bridgeDir, "e2e_test.go")
 	if !fileExists(bootstrapPath) || opts.ForceBootstrap {
-		if err := renderE2EFile(bootstrapPath, bridgeE2EBootstrapTemplate, e2e, opts); err != nil {
+		if err := renderE2EFile(bootstrapPath, bridgeE2EBootstrapTemplate, "bridge-e2e/e2e_test.go", e2e, opts); err != nil {
 			return err
 		}
 		fmt.Printf("      create %s\n", bootstrapPath)
@@ -114,7 +114,7 @@ func GenerateBridgeE2E(data BridgeTemplateData, resolved *ResolvedFile, bridgeDi
 	return nil
 }
 
-func renderE2EFile(path, tmplText string, e2e BridgeE2EData, opts Options) error {
+func renderE2EFile(path, tmplText, bootstrapKind string, e2e BridgeE2EData, opts Options) error {
 	tmpl, err := template.New("bridge_e2e").Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("parse e2e template: %w", err)
@@ -123,7 +123,11 @@ func renderE2EFile(path, tmplText string, e2e BridgeE2EData, opts Options) error
 	if err := tmpl.Execute(&buf, e2e); err != nil {
 		return fmt.Errorf("render %s: %w", path, err)
 	}
-	return renderGoFile(path, buf.Bytes(), path, opts)
+	out := buf.Bytes()
+	if bootstrapKind != "" {
+		out = prependBootstrapMarker(bootstrapKind, out)
+	}
+	return renderGoFile(path, out, path, opts)
 }
 
 // FKSeed is one foreign-key create field whose value comes from a parent row
@@ -349,4 +353,3 @@ func pkOnlyPathExpr(path, pkParam string) (string, bool) {
 	}
 	return strings.Join(exprs, " + "), true
 }
-

--- a/workshop/codegen/generators/bridge_security_gen.go
+++ b/workshop/codegen/generators/bridge_security_gen.go
@@ -50,14 +50,14 @@ func GenerateBridgeSecurity(data BridgeTemplateData, resolved *ResolvedFile, bri
 		return nil
 	}
 
-	if err := renderSecurityFile(path, bridgeSecurityGeneratedTemplate, sec, opts); err != nil {
+	if err := renderSecurityFile(path, bridgeSecurityGeneratedTemplate, "", sec, opts); err != nil {
 		return err
 	}
 	fmt.Printf("      write %s\n", path)
 
 	bootstrapPath := filepath.Join(bridgeDir, "security_test.go")
 	if !fileExists(bootstrapPath) || opts.ForceBootstrap {
-		if err := renderSecurityFile(bootstrapPath, bridgeSecurityBootstrapTemplate, sec, opts); err != nil {
+		if err := renderSecurityFile(bootstrapPath, bridgeSecurityBootstrapTemplate, "bridge-security/security_test.go", sec, opts); err != nil {
 			return err
 		}
 		fmt.Printf("      create %s\n", bootstrapPath)
@@ -137,7 +137,7 @@ func substituteProbeParams(path string) string {
 	return string(out)
 }
 
-func renderSecurityFile(path, tmplText string, sec BridgeSecurityData, opts Options) error {
+func renderSecurityFile(path, tmplText, bootstrapKind string, sec BridgeSecurityData, opts Options) error {
 	tmpl, err := template.New("bridge_security").Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("parse security template: %w", err)
@@ -146,5 +146,9 @@ func renderSecurityFile(path, tmplText string, sec BridgeSecurityData, opts Opti
 	if err := tmpl.Execute(&buf, sec); err != nil {
 		return fmt.Errorf("render %s: %w", path, err)
 	}
-	return renderGoFile(path, buf.Bytes(), path, opts)
+	out := buf.Bytes()
+	if bootstrapKind != "" {
+		out = prependBootstrapMarker(bootstrapKind, out)
+	}
+	return renderGoFile(path, out, path, opts)
 }

--- a/workshop/codegen/generators/cache.go
+++ b/workshop/codegen/generators/cache.go
@@ -82,6 +82,10 @@ func GenerateCache(resolved *ResolvedFile, repoDir string, multiHomed bool, opts
 			return false, fmt.Errorf("render %s for %s: %w", f.name, resolved.TableName, err)
 		}
 
+		if f.bootstrap {
+			out = prependBootstrapMarker("cache/"+f.name, out)
+		}
+
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
 			return false, err
 		}
@@ -92,9 +96,9 @@ func GenerateCache(resolved *ResolvedFile, repoDir string, multiHomed bool, opts
 
 func buildCacheData(resolved *ResolvedFile) (CacheTemplateData, error) {
 	data := CacheTemplateData{
-		PackageName:   RepoPackage(resolved.TableName),
-		EntityName:    resolved.EntityName,
-		KeyPrefix:     resolved.DomainName + ":" + resolved.TableName,
+		PackageName: RepoPackage(resolved.TableName),
+		EntityName:  resolved.EntityName,
+		KeyPrefix:   resolved.DomainName + ":" + resolved.TableName,
 	}
 
 	// Build method signatures from resolved queries (reuse the repo method builder logic).

--- a/workshop/codegen/generators/fixture.go
+++ b/workshop/codegen/generators/fixture.go
@@ -15,14 +15,14 @@ import (
 
 // ParentFixture describes a FK dependency on another entity.
 type ParentFixture struct {
-	VarName                string // camelCase param name, e.g. "serviceAccountID"
-	EntityName             string // PascalCase parent entity, e.g. "ServiceAccount"
-	TableName              string // parent table name, e.g. "service_accounts"
-	FKColumn               string // FK column on this table, e.g. "service_account_id"
-	PKGoName               string // parent's PK Go field, e.g. "ServiceAccountID"
-	IsSelfReference        bool   // FK references same table
-	IsPrincipalInheritance bool   // PK is FK to principals table
-	IsInBatch              bool   // parent table has a fixture in this generation batch
+	VarName                string          // camelCase param name, e.g. "serviceAccountID"
+	EntityName             string          // PascalCase parent entity, e.g. "ServiceAccount"
+	TableName              string          // parent table name, e.g. "service_accounts"
+	FKColumn               string          // FK column on this table, e.g. "service_account_id"
+	PKGoName               string          // parent's PK Go field, e.g. "ServiceAccountID"
+	IsSelfReference        bool            // FK references same table
+	IsPrincipalInheritance bool            // PK is FK to principals table
+	IsInBatch              bool            // parent table has a fixture in this generation batch
 	ForwardParams          []ParentFixture // external params to forward when calling this in-batch parent's WithDefaults
 }
 
@@ -47,11 +47,11 @@ type FixtureEntity struct {
 	RepoPkg     string // e.g. "users"
 	RepoImport  string // full import path
 
-	PKColumn   string // e.g. "user_id"
-	PKGoName   string // e.g. "UserID"
-	PKGoType   string // e.g. "string"
-	PKIsFK     bool   // true if PK is also a FK (use param, don't generate)
-	PKIsUUID   bool   // true when the PK column is a uuid — GenerateID's alphabet is rejected
+	PKColumn string // e.g. "user_id"
+	PKGoName string // e.g. "UserID"
+	PKGoType string // e.g. "string"
+	PKIsFK   bool   // true if PK is also a FK (use param, don't generate)
+	PKIsUUID bool   // true when the PK column is a uuid — GenerateID's alphabet is rejected
 
 	// InsertFields are the columns the fixture INSERT will populate.
 	InsertFields []FixtureField
@@ -96,11 +96,11 @@ type FixtureField struct {
 
 // FixtureTemplateData holds all data for rendering the fixtures file.
 type FixtureTemplateData struct {
-	ModulePath    string
-	SpecMode      bool   // sqlite/spec fixtures (testsqlite, ? placeholders) vs pgx
-	Entities      []FixtureEntity
-	Imports       []string // deduplicated extra imports
-	NeedsTime     bool     // "time" is among Imports — gates the usage guard
+	ModulePath string
+	SpecMode   bool // sqlite/spec fixtures (testsqlite, ? placeholders) vs pgx
+	Entities   []FixtureEntity
+	Imports    []string // deduplicated extra imports
+	NeedsTime  bool     // "time" is among Imports — gates the usage guard
 }
 
 // BuildFixtureEntity creates a FixtureEntity from a ResolvedFile.
@@ -540,6 +540,10 @@ func generateFixturesWith(data FixtureTemplateData, fixtureDir string, opts Opti
 		out, err := renderFixtureTemplate(f.tmpl, data)
 		if err != nil {
 			return fmt.Errorf("render %s: %w", f.name, err)
+		}
+
+		if f.bootstrap {
+			out = prependBootstrapMarker("fixtures/"+f.name, out)
 		}
 
 		if err := renderGoFile(f.name, out, path, opts); err != nil {

--- a/workshop/codegen/generators/integration_test_gen.go
+++ b/workshop/codegen/generators/integration_test_gen.go
@@ -30,8 +30,8 @@ type IntegrationTestMethod struct {
 	HasUpdate bool
 
 	// For exec (soft delete, archive, restore, hard delete)
-	IsDelete    bool // hard delete
-	IsSoftState bool // soft delete / archive / restore
+	IsDelete    bool   // hard delete
+	IsSoftState bool   // soft delete / archive / restore
 	NewState    string // e.g. "deleted", "archived", "active"
 
 	// For update_returning
@@ -47,9 +47,9 @@ type IntegrationTestData struct {
 	SpecMode bool
 
 	// Package info
-	StorePkg   string // e.g. "userspgx"
-	RepoPkg    string // e.g. "users"
-	EntityName string // e.g. "User"
+	StorePkg    string // e.g. "userspgx"
+	RepoPkg     string // e.g. "users"
+	EntityName  string // e.g. "User"
 	EntityLower string // e.g. "user"
 
 	// Import paths
@@ -604,6 +604,10 @@ func generateIntegrationTestWith(data IntegrationTestData, storeDir string, opts
 		out, err := renderIntegrationTestTemplate(f.tmpl, data)
 		if err != nil {
 			return fmt.Errorf("render %s for %s: %w", f.name, data.StorePkg, err)
+		}
+
+		if f.bootstrap {
+			out = prependBootstrapMarker("integrationtest/"+f.name, out)
 		}
 
 		if err := renderGoFile(f.name, out, path, opts); err != nil {

--- a/workshop/codegen/generators/pgxstore.go
+++ b/workshop/codegen/generators/pgxstore.go
@@ -50,9 +50,9 @@ func (f SearchFieldInfo) SQLName() string {
 
 // StoreFilter holds data for one named filter in a list method.
 type StoreFilter struct {
-	PlaceholderName string // "conditions"
-	GenFuncName     string // "generatedApplyListUsersConditionsFilter"
-	FilterTypeName  string // "FilterListUsers" (copied from parent for template access)
+	PlaceholderName    string           // "conditions"
+	GenFuncName        string           // "generatedApplyListUsersConditionsFilter"
+	FilterTypeName     string           // "FilterListUsers" (copied from parent for template access)
 	Fields             []StoreFieldInfo // resolved fields for this filter
 	HasRecordState     bool             // this filter includes record_state
 	RecordStateSQLName string           // qualified name for record_state in SQL (e.g. "u.record_state")
@@ -85,10 +85,10 @@ type StoreMethod struct {
 	HasAppUpdatedAt bool // entity has updated_at but it's excluded from @fields
 
 	// For update / update_returning.
-	UpdateFields        []StoreFieldInfo
+	UpdateFields []StoreFieldInfo
 	// WhereParams are the update's WHERE predicates, one per SQL @param —
 	// composite keys carry more than one (joined with AND).
-	WhereParams []StoreWhereParam
+	WhereParams         []StoreWhereParam
 	HasUpdatedAt        bool
 	UpdateReturningCols string
 
@@ -104,11 +104,11 @@ type StoreMethod struct {
 
 	// For list — named filters with placeholder substitution.
 	FilterTypeName      string
-	Filters             []StoreFilter    // one per named filter
+	Filters             []StoreFilter // one per named filter
 	SearchFields        []SearchFieldInfo
 	SearchType          string
 	HasSearch           bool
-	GenSearchFunc string // generated: "generatedApplyListUsersSearchFilter"
+	GenSearchFunc       string // generated: "generatedApplyListUsersSearchFilter"
 	RecordStateInFilter bool   // any filter includes record_state
 
 	// List sub-features (for conditional template rendering).
@@ -191,6 +191,10 @@ func GeneratePgxStore(
 			return fmt.Errorf("render %s for %s: %w", f.name, resolved.TableName, err)
 		}
 
+		if f.bootstrap {
+			out = prependBootstrapMarker("pgxstore/"+f.name, out)
+		}
+
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
 			return err
 		}
@@ -216,7 +220,6 @@ func renderStoreTemplate(tmplText string, data StoreTemplateData) ([]byte, error
 	}
 	return buf.Bytes(), nil
 }
-
 
 func buildStoreData(resolved *ResolvedFile, domainName, modulePath string) (StoreTemplateData, error) {
 	repoPkg := RepoPackage(resolved.TableName)

--- a/workshop/codegen/generators/repository.go
+++ b/workshop/codegen/generators/repository.go
@@ -125,12 +125,12 @@ type RepoTemplateData struct {
 	Filters []FilterInfo
 	Methods []MethodSig
 
-	HasCreate        bool
-	HasUpdate        bool
-	HasFilter        bool
-	HasList          bool
-	HasSoftDelete    bool
-	HasPKInCreate    bool
+	HasCreate     bool
+	HasUpdate     bool
+	HasFilter     bool
+	HasList       bool
+	HasSoftDelete bool
+	HasPKInCreate bool
 	// HasRecordStateInCreate gates the create-time record_state default:
 	// only valid when record_state is among the create @fields — otherwise
 	// the column's SQL default applies and the Create model has no field.
@@ -147,7 +147,6 @@ type RepoTemplateData struct {
 	// has defined their own in repository.go.
 	SkipStorer bool
 }
-
 
 // GenerateRepository produces flat repository layer files (standard).
 // Types use final names, Repository struct + methods are in generated.go,
@@ -182,6 +181,10 @@ func GenerateRepository(resolved *ResolvedFile, repoDir string, opts Options) er
 		out, err := renderRepoTemplate(f.tmpl, data)
 		if err != nil {
 			return fmt.Errorf("render %s for %s: %w", f.name, resolved.TableName, err)
+		}
+
+		if f.bootstrap {
+			out = prependBootstrapMarker("repository/"+f.name, out)
 		}
 
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
@@ -442,35 +445,35 @@ func buildRepoTemplateData(resolved *ResolvedFile) (RepoTemplateData, error) {
 	}
 
 	return RepoTemplateData{
-		PackageName:       resolved.PackageName,
-		EntityName:        resolved.EntityName,
-		EntityNameLower:   resolved.EntityLower,
-		EntityNameSpaced:  ToSpaced(strings.ToLower(resolved.EntityName)),
-		EntityNamePlural:  resolved.EntityPlural,
-		CreateName:        "Create" + resolved.EntityName,
-		UpdateName:        "Update" + resolved.EntityName,
-		PKColumn:          resolved.PKColumn,
-		PKGoName:          resolved.PKGoName,
-		PKGoType:          resolved.PKGoType,
-		DefaultOrderConst: defaultOrderConst,
-		EntityFields:      entityFields,
-		CreateFields:      createFields,
-		UpdateFields:      updateFields,
-		OrderByFields:     orderByFields,
-		CursorFields:      cursorFields,
-		ExtraImports:      extraImports,
-		Filters:           filters,
-		Methods:           methods,
-		HasCreate:         hasCreate,
-		HasUpdate:         hasUpdate,
-		HasFilter:         hasFilter,
-		HasList:           hasList,
+		PackageName:            resolved.PackageName,
+		EntityName:             resolved.EntityName,
+		EntityNameLower:        resolved.EntityLower,
+		EntityNameSpaced:       ToSpaced(strings.ToLower(resolved.EntityName)),
+		EntityNamePlural:       resolved.EntityPlural,
+		CreateName:             "Create" + resolved.EntityName,
+		UpdateName:             "Update" + resolved.EntityName,
+		PKColumn:               resolved.PKColumn,
+		PKGoName:               resolved.PKGoName,
+		PKGoType:               resolved.PKGoType,
+		DefaultOrderConst:      defaultOrderConst,
+		EntityFields:           entityFields,
+		CreateFields:           createFields,
+		UpdateFields:           updateFields,
+		OrderByFields:          orderByFields,
+		CursorFields:           cursorFields,
+		ExtraImports:           extraImports,
+		Filters:                filters,
+		Methods:                methods,
+		HasCreate:              hasCreate,
+		HasUpdate:              hasUpdate,
+		HasFilter:              hasFilter,
+		HasList:                hasList,
 		HasSoftDelete:          hasSoftDelete,
 		HasPKInCreate:          hasPKInCreate,
 		HasRecordStateInCreate: hasRecordStateInCreate,
 		PKIsUUID:               pkIsUUID(resolved),
-		DefaultDirection:  defaultDirection,
-		Events:            events,
+		DefaultDirection:       defaultDirection,
+		Events:                 events,
 	}, nil
 }
 

--- a/workshop/codegen/generators/specstore.go
+++ b/workshop/codegen/generators/specstore.go
@@ -76,10 +76,10 @@ type SpecSkippedFunc struct {
 
 // SpecStoreData holds everything needed to render the specstore templates.
 type SpecStoreData struct {
-	PackageName   string
-	RepoPkg       string
-	RepoImport    string
-	EntityName    string
+	PackageName string
+	RepoPkg     string
+	RepoImport  string
+	EntityName  string
 
 	Table         string
 	PK            string
@@ -169,6 +169,10 @@ func GenerateSpecStore(resolved *ResolvedFile, repoDir, modulePath string, opts 
 			return fmt.Errorf("render %s for %s: %w", f.name, resolved.TableName, err)
 		}
 
+		if f.bootstrap {
+			out = prependBootstrapMarker("specstore/"+f.name, out)
+		}
+
 		if err := renderGoFile(f.name, out, path, opts); err != nil {
 			return err
 		}
@@ -246,12 +250,12 @@ func BuildSpecStoreData(resolved *ResolvedFile, modulePath string) (SpecStoreDat
 	repoImport += repoPkg
 
 	data := SpecStoreData{
-		PackageName:   StorePackage(resolved.TableName, specStorePackageSuffix),
-		RepoPkg:       repoPkg,
-		RepoImport:    repoImport,
-		EntityName:    resolved.EntityName,
-		Table:         resolved.TableName, // no schema prefix — dialect-neutral
-		PK:            resolved.PKColumn,
+		PackageName: StorePackage(resolved.TableName, specStorePackageSuffix),
+		RepoPkg:     repoPkg,
+		RepoImport:  repoImport,
+		EntityName:  resolved.EntityName,
+		Table:       resolved.TableName, // no schema prefix — dialect-neutral
+		PK:          resolved.PKColumn,
 	}
 
 	hasRecordState := false

--- a/workshop/documentation/docs/cli/doctor.md
+++ b/workshop/documentation/docs/cli/doctor.md
@@ -118,6 +118,27 @@ Walks `bridge.yml` files and warns when a write route (Create/Update) has no
 `max_body_size` middleware -- unbounded request bodies are a
 resource-exhaustion vector. A warning, not a failure.
 
+### 8. Bootstrap template drift
+
+Bootstrap files created at v0.4+ carry a first-line marker recording which
+framework template created them:
+
+```go
+// gopernicus:bootstrap kind=repository/fop.go template=f199aa94a337
+```
+
+Doctor compares each marker's hash against the current framework's template
+for that kind. The hash covers the *template*, not the file -- your edits to
+bootstrap files never count as drift.
+
+- **Pass**: all marked bootstraps match the current templates. The detail
+  reports how many files are tracked, and how many pre-v0.4 bootstraps have
+  no marker yet (they start tracking when refreshed or newly created).
+- **Warning**: a file was created from an older template that has since
+  changed -- review the release notes or refresh the file (see the
+  [upgrading guide](../guides/upgrading.md)). Never a failure: bootstraps
+  are user-owned and refreshing is a deliberate act.
+
 ## Output Format
 
 Each check is displayed with a symbol prefix:

--- a/workshop/documentation/docs/guides/upgrading.md
+++ b/workshop/documentation/docs/guides/upgrading.md
@@ -83,7 +83,13 @@ endpoint. Green tests alone are not a release gate.
 
 Bootstrap files are created once and never overwritten, so a project
 carries them at the template vintage of whatever version first generated
-them. When a release improves a bootstrap template:
+them. Files created at v0.4+ carry a first-line marker
+(`// gopernicus:bootstrap kind=... template=<hash>`) that
+`gopernicus doctor` compares against the current framework's templates —
+after every upgrade, doctor's `bootstrap: template drift` check tells you
+which files were created from templates that have since changed.
+
+When a release improves a bootstrap template:
 
 - `go tool gopernicus generate --force-bootstrap` overwrites **all**
   bootstrap files. Never run this blindly on a project with customized

--- a/workshop/gopernicus/commands/doctor.go
+++ b/workshop/gopernicus/commands/doctor.go
@@ -83,6 +83,7 @@ func runDoctor(_ context.Context, args []string) error {
 	}
 	checks = append(checks, checkSQLGuards(root)...)
 	checks = append(checks, checkBodyLimits(root))
+	checks = append(checks, checkBootstrapDrift(root))
 
 	result := buildDoctorResult(root, frameworkVersion, checks)
 
@@ -284,6 +285,98 @@ func checkBodyLimits(root string) check {
 		detail = fmt.Sprintf("%s (+%d more)", detail, len(unbounded)-1)
 	}
 	return check{name: "bridge: write routes bound body size", passed: true, warn: true, detail: detail}
+}
+
+// checkBootstrapDrift compares each bootstrap file's creation marker
+// (`// gopernicus:bootstrap kind=... template=<hash>`) against the current
+// framework's template hash for that kind. A mismatch means the file was
+// created from an older template — a warning, never a failure: bootstraps
+// are user-owned and refresh is a deliberate act. Conventionally-named
+// bootstrap files without a marker (created before v0.4) are counted in
+// the detail so the one-time refresh path is visible.
+func checkBootstrapDrift(root string) check {
+	const name = "bootstrap: template drift"
+
+	basenames := generators.BootstrapBasenames()
+	var drifted []string
+	tracked, unmarked := 0, 0
+
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !basenames[d.Name()] || !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		if !strings.HasPrefix(rel, "core"+string(filepath.Separator)) &&
+			!strings.HasPrefix(rel, "bridge"+string(filepath.Separator)) &&
+			!strings.HasPrefix(rel, filepath.Join("workshop", "testing")+string(filepath.Separator)) {
+			return nil
+		}
+
+		firstLine, rerr := readFirstLine(path)
+		if rerr != nil {
+			return nil
+		}
+		kind, hash, ok := generators.ParseBootstrapMarker(firstLine)
+		if !ok {
+			unmarked++
+			return nil
+		}
+		current, known := generators.BootstrapTemplateHash(kind)
+		if !known {
+			// Marker from a different framework vintage whose kind no
+			// longer exists — surface it as drift, the honest reading.
+			drifted = append(drifted, rel+" (unknown kind "+kind+")")
+			return nil
+		}
+		tracked++
+		if hash != current {
+			drifted = append(drifted, rel)
+		}
+		return nil
+	})
+
+	if len(drifted) > 0 {
+		detail := drifted[0] + " created from an older template — review or refresh (see the upgrading guide)"
+		if len(drifted) > 1 {
+			detail = fmt.Sprintf("%s (+%d more)", detail, len(drifted)-1)
+		}
+		return check{name: name, passed: true, warn: true, detail: detail}
+	}
+
+	detail := ""
+	switch {
+	case tracked > 0 && unmarked > 0:
+		detail = fmt.Sprintf("%d tracked; %d pre-marker bootstrap files (created before v0.4)", tracked, unmarked)
+	case tracked > 0:
+		detail = fmt.Sprintf("%d tracked", tracked)
+	case unmarked > 0:
+		detail = fmt.Sprintf("%d pre-marker bootstrap files (created before v0.4 — refresh to start tracking)", unmarked)
+	}
+	return check{name: name, passed: true, detail: detail}
+}
+
+// readFirstLine returns the first line of a file without reading the rest.
+func readFirstLine(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	if scanner.Scan() {
+		return scanner.Text(), nil
+	}
+	return "", scanner.Err()
 }
 
 // checkFrameworkDep verifies the framework pin in go.mod and also returns

--- a/workshop/gopernicus/commands/doctor_test.go
+++ b/workshop/gopernicus/commands/doctor_test.go
@@ -2,7 +2,12 @@ package commands
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/gopernicus/gopernicus/workshop/codegen/generators"
 )
 
 // The JSON field names are a stable contract — agents and scripts parse
@@ -78,6 +83,86 @@ func TestDoctorResultJSONShape(t *testing.T) {
 	if _, present := first["warn"]; present {
 		t.Error("warn=false must be omitted")
 	}
+}
+
+func writeBootstrapFixture(t *testing.T, root, rel, firstLine string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := firstLine + "\npackage x\n"
+	if firstLine == "" {
+		content = "package x\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckBootstrapDrift(t *testing.T) {
+	currentHash, ok := generators.BootstrapTemplateHash("repository/repository.go")
+	if !ok {
+		t.Fatal("repository/repository.go not in registry")
+	}
+	marker := func(kind, hash string) string {
+		return "// gopernicus:bootstrap kind=" + kind + " template=" + hash
+	}
+
+	t.Run("current marker passes", func(t *testing.T) {
+		root := t.TempDir()
+		writeBootstrapFixture(t, root, "core/repositories/d/e/repository.go", marker("repository/repository.go", currentHash))
+		c := checkBootstrapDrift(root)
+		if !c.passed || c.warn {
+			t.Errorf("check = %+v, want pass without warn", c)
+		}
+		if !strings.Contains(c.detail, "1 tracked") {
+			t.Errorf("detail = %q", c.detail)
+		}
+	})
+
+	t.Run("stale marker warns", func(t *testing.T) {
+		root := t.TempDir()
+		writeBootstrapFixture(t, root, "core/repositories/d/e/repository.go", marker("repository/repository.go", "000000000000"))
+		c := checkBootstrapDrift(root)
+		if !c.passed || !c.warn {
+			t.Errorf("check = %+v, want pass with warn", c)
+		}
+		if !strings.Contains(c.detail, "repository.go") || !strings.Contains(c.detail, "older template") {
+			t.Errorf("detail = %q", c.detail)
+		}
+	})
+
+	t.Run("unknown kind warns as drift", func(t *testing.T) {
+		root := t.TempDir()
+		writeBootstrapFixture(t, root, "bridge/repositories/foo/bridge.go", marker("retired/bridge.go", "abcabcabcabc"))
+		c := checkBootstrapDrift(root)
+		if !c.warn || !strings.Contains(c.detail, "unknown kind") {
+			t.Errorf("check = %+v, want unknown-kind drift warn", c)
+		}
+	})
+
+	t.Run("pre-marker files counted not warned", func(t *testing.T) {
+		root := t.TempDir()
+		writeBootstrapFixture(t, root, "core/repositories/d/e/repository.go", "")
+		writeBootstrapFixture(t, root, "bridge/repositories/foo/bridge.go", "// plain comment")
+		c := checkBootstrapDrift(root)
+		if !c.passed || c.warn {
+			t.Errorf("check = %+v, want plain pass", c)
+		}
+		if !strings.Contains(c.detail, "2 pre-marker") {
+			t.Errorf("detail = %q", c.detail)
+		}
+	})
+
+	t.Run("files outside generated trees ignored", func(t *testing.T) {
+		root := t.TempDir()
+		writeBootstrapFixture(t, root, "app/server/store.go", marker("pgxstore/store.go", "000000000000"))
+		c := checkBootstrapDrift(root)
+		if c.warn || c.detail != "" {
+			t.Errorf("check = %+v, want empty pass", c)
+		}
+	})
 }
 
 func TestHasFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

v0.4 plan item 3. Bootstrap files are created once and never overwritten, so a project carries them at the template vintage that first generated them — and nothing recorded that vintage. Two segovia migration findings (the nil-stub `migrateTestDB`, the `setupTestStore` duplication) were exactly this invisible-drift class.

**Marker at creation** (first line of every new bootstrap file):
```go
// gopernicus:bootstrap kind=repository/fop.go template=f199aa94a337
```
The hash covers the *template constant*, never the rendered file — user edits to bootstraps are expected and never count as drift.

**Registry** (`bootstrap_registry.go`): all 14 bootstrap kinds across 10 generators, mapped to their template constants. `prependBootstrapMarker` panics on an unregistered kind, so adding a bootstrap genFile without registering it fails loud at develop time (same doctrine as the featurespecs snapshot).

**Doctor check** `bootstrap: template drift`: warn (never fail) naming the drifted file, with pre-v0.4 unmarked bootstraps counted in the detail rather than nagged. Flows into `doctor --json` automatically.

## Verification (real consumer, then restored)

In segovia with the dev binary:
1. Recreated one clean bootstrap (`tenantsettings/fop.go`) → marker appears, doctor reports `✓ ... 1 tracked; 299 pre-marker bootstrap files`.
2. Edited the marker hash to simulate an older vintage → `! ... fop.go created from an older template — review or refresh (see the upgrading guide)`, and the same warn in `--json`.
3. Restored segovia byte-for-byte (`git checkout` the file).

Framework repo: `gopernicus generate` after the change produces zero drift (existing bootstraps never rewritten), all generator + command tests pass, and the framework's own 170 pre-marker bootstraps are counted quietly.

Docs: doctor.md check #8, upgrading-guide pointer, CHANGELOG Unreleased entry.

## Note for a future sweep
`gofmt -l` shows ~10 pre-existing unformatted files repo-wide (newer Go's gofmt) — untouched here; candidate for a standalone cleanup + CI format gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)