### PR TITLE
fix(sdk/async): count panics before wg.Done — Wait/Stats torn reads

### DIFF
--- a/sdk/async/pool.go
+++ b/sdk/async/pool.go
@@ -212,10 +212,9 @@ func (p *Pool) GoContext(ctx context.Context, fn func()) bool {
 
 func (p *Pool) execute(fn func()) {
 	defer func() {
-		<-p.semaphore
-		atomic.AddInt64(&p.active, -1)
-		p.wg.Done()
-
+		// Panic accounting must complete before wg.Done() — otherwise
+		// Wait() can return while the panic counter is still unwritten
+		// and a Wait()-then-Stats() caller reads a torn count.
 		if r := recover(); r != nil {
 			atomic.AddInt64(&p.panics, 1)
 			p.log.Error("async pool: panic recovered",
@@ -223,6 +222,10 @@ func (p *Pool) execute(fn func()) {
 				"stack", string(debug.Stack()),
 			)
 		}
+
+		<-p.semaphore
+		atomic.AddInt64(&p.active, -1)
+		p.wg.Done()
 	}()
 
 	fn()


### PR DESCRIPTION
## Summary

PR #32's (unrelated) integration run failed on `TestPool_PanicRecovery` — `Panics = 0, want 1`. The cause is a real ordering bug in `Pool.execute`, not test flakiness: the deferred cleanup ran `p.wg.Done()` **before** `recover()` incremented the panic counter, so `Wait()` could return — and a `Wait()`-then-`Stats()` caller read a torn count — before panic accounting completed.

Fix: reorder the deferred block — recover/count first, then semaphore release, `active` decrement, and `wg.Done()` last. `Wait()` now returns only after panic accounting is fully written.

## Verification
- Reproduced pre-fix: `go test -race -count=500 -run "TestPool_PanicRecovery|TestPool_MultiplePanics" ./sdk/async/` → FAIL.
- Post-fix: 2000 runs under `-race` green; full `sdk/async` suite green.

That's the third latent defect the CI gates have surfaced since landing (go.mod/MinGoVersion drift, JWT malleability, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)