### PR TITLE
feat(testing): authenticated e2e phase A — real credential seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,31 @@ Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
   when a file's template has since changed. The hash covers the template,
   never the file — your edits to bootstraps don't count as drift.
 
+- Authenticated e2e groundwork (phase A): generated fixtures accept
+  per-call column overrides (`CreateTestX(t, ctx, db, …,
+  map[string]any{"col": v})` — variadic, existing call sites compile
+  unchanged; unknown columns and the PK fail loud);
+  `authentication.HashToken` is exported so harnesses seed credential
+  rows the engine will match; `testauth.AuthenticatorWithRepositories`
+  wires the real database-backed authentication modes.
+
+### Fixed
+- Generated fixture defaults now produce live rows: `*expires_at` columns
+  default 24h in the future (was `now()` — expired at birth) and
+  tombstone columns (`revoked_at`, `deleted_at`, `archived_at`,
+  `disabled_at`, `removed_at`) default NULL (was a non-NULL timestamp —
+  revoked at birth). Spec-mode TimeArg encoding preserves the time
+  expression instead of replacing it wholesale.
+
 ### Consumer actions
 - [ ] None required. Scripts may now gate on
       `go tool gopernicus doctor --json | jq -e '.ok'`.
 - [ ] Existing bootstrap files have no markers and are reported as a
       pre-marker count, not warnings; they start tracking when refreshed
       or newly created.
+- [ ] Regenerate. If any hand-written test relied on fixture rows being
+      expired/revoked at creation, it now needs an explicit override
+      (e.g. `map[string]any{"expires_at": time.Now()}`).
 
 ## v0.3.5 — 2026-06-11
 

--- a/core/auth/authentication/crypto.go
+++ b/core/auth/authentication/crypto.go
@@ -20,6 +20,15 @@ func generateToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// HashToken returns the canonical hash the engine applies to bearer
+// credentials (session tokens, API keys) before storage and lookup.
+// Exported so test harnesses can seed credential rows the engine will
+// actually match — a private re-implementation in tests would drift
+// silently if the algorithm ever changed.
+func HashToken(token string) (string, error) {
+	return hashToken(token)
+}
+
 // hashToken returns the SHA256 hash of a token as a hex string.
 // Returns an error for empty input to prevent accidental hash-of-nothing comparisons.
 func hashToken(token string) (string, error) {

--- a/core/auth/authentication/crypto_test.go
+++ b/core/auth/authentication/crypto_test.go
@@ -1,0 +1,23 @@
+package authentication
+
+import "testing"
+
+// HashToken is the exported seam test harnesses use to seed credential rows
+// the engine will match — it must stay identical to the internal hash.
+func TestHashTokenMatchesInternal(t *testing.T) {
+	exported, err := HashToken("some-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	internal, err := hashToken("some-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exported != internal {
+		t.Errorf("HashToken = %q, hashToken = %q — the exported seam drifted", exported, internal)
+	}
+
+	if _, err := HashToken(""); err == nil {
+		t.Error("empty token must error")
+	}
+}

--- a/workshop/codegen/generators/fixture.go
+++ b/workshop/codegen/generators/fixture.go
@@ -460,7 +460,10 @@ func GenerateSpecFixtures(data FixtureTemplateData, fixtureDir string, opts Opti
 // specEncodeTimeDefaults rewrites time-typed insert defaults to go through
 // the dialect's TimeArg encoding. Binding a raw time.Time stores Go's
 // String() rendering in TEXT columns, which crud's scanner rejects; the
-// stores themselves encode via timeAware, fixtures must match. InsertFields
+// stores themselves encode via timeAware, fixtures must match. The original
+// time expression is preserved inside the TimeArg wrap (a future-expiry
+// default must stay in the future), with any conversion.Ptr unwrapped —
+// TimeArg takes a value and INSERT args are []any either way. InsertFields
 // is deep-copied first — multi-homed entities share backing arrays with the
 // pgx fixture list.
 func specEncodeTimeDefaults(entities []FixtureEntity) {
@@ -469,7 +472,11 @@ func specEncodeTimeDefaults(entities []FixtureEntity) {
 		copy(fields, entities[i].InsertFields)
 		for j, f := range fields {
 			if strings.Contains(f.TestDefault, "time.Now()") {
-				fields[j].TestDefault = "db.Dialect().TimeArg(time.Now().UTC())"
+				inner := f.TestDefault
+				if unwrapped, ok := strings.CutPrefix(inner, "conversion.Ptr("); ok {
+					inner = strings.TrimSuffix(unwrapped, ")")
+				}
+				fields[j].TestDefault = "db.Dialect().TimeArg(" + inner + ")"
 			}
 		}
 		entities[i].InsertFields = fields
@@ -689,12 +696,28 @@ func columnToFixture(col schema.ColumnInfo) FixtureField {
 	return ff
 }
 
+// tombstoneTimeColumns are nullable time columns whose non-NULL value marks
+// the row as dead (revoked, deleted, …). The generic fixture used to fill
+// them like any nullable column, producing rows tombstoned at birth —
+// credentials that can never authenticate, records that read as deleted.
+// Fixtures represent live rows; tombstones default to NULL.
+var tombstoneTimeColumns = map[string]bool{
+	"revoked_at":  true,
+	"deleted_at":  true,
+	"archived_at": true,
+	"disabled_at": true,
+	"removed_at":  true,
+}
+
 func testDefaultForField(f FixtureField) string {
 	dbName := strings.ToLower(f.DBName)
 
 	// Handle nullable pointer types.
 	if f.IsNullable && strings.HasPrefix(f.GoType, "*") {
 		innerType := f.GoType[1:]
+		if innerType == "time.Time" && tombstoneTimeColumns[dbName] {
+			return "nil"
+		}
 		switch innerType {
 		case "string":
 			return fmt.Sprintf(`conversion.Ptr("test_%s")`, dbName)
@@ -705,6 +728,11 @@ func testDefaultForField(f FixtureField) string {
 		case "float64":
 			return "conversion.Ptr(0.0)"
 		case "time.Time":
+			// Expiry columns must be in the future — a fixture row expired
+			// at birth can never authenticate or validate.
+			if strings.HasSuffix(dbName, "expires_at") {
+				return "conversion.Ptr(time.Now().UTC().Add(24 * time.Hour))"
+			}
 			return "conversion.Ptr(time.Now().UTC())"
 		case "json.RawMessage":
 			// Postgres rejects empty bytes as invalid JSON; emit `{}` so the
@@ -755,6 +783,9 @@ func testDefaultForField(f FixtureField) string {
 	case "float64":
 		return "0.0"
 	case "time.Time":
+		if strings.HasSuffix(dbName, "expires_at") {
+			return "time.Now().UTC().Add(24 * time.Hour)"
+		}
 		return "time.Now().UTC()"
 	case "[]byte":
 		return `[]byte("test")`

--- a/workshop/codegen/generators/fixture_test.go
+++ b/workshop/codegen/generators/fixture_test.go
@@ -242,6 +242,97 @@ func TestFixtureDefaultOverridesEmittedSpecMode(t *testing.T) {
 	}
 }
 
+// credentialResolved builds a sessions-shaped entity: hash + expiry +
+// tombstone columns, the shape the authenticated e2e stack seeds.
+func credentialResolved() *ResolvedFile {
+	return &ResolvedFile{
+		Table:       &schema.TableInfo{TableName: "sessions"},
+		EntityName:  "Session",
+		EntityLower: "session",
+		TableName:   "sessions",
+		PackageName: "sessions",
+		DomainName:  "auth",
+		PKColumn:    "session_id",
+		PKGoName:    "SessionID",
+		PKGoType:    "string",
+		AllColumns: []schema.ColumnInfo{
+			{Name: "session_id", DBType: "text", GoType: "string", IsPrimaryKey: true},
+			{Name: "session_token_hash", DBType: "text", GoType: "string"},
+			{Name: "expires_at", DBType: "timestamptz", GoType: "time.Time", GoImport: "time"},
+			{Name: "revoked_at", DBType: "timestamptz", GoType: "*time.Time", GoImport: "time", IsNullable: true},
+		},
+	}
+}
+
+// Fixture rows must be live at birth: expiry columns default to the future
+// and tombstone columns (revoked_at and friends) default to NULL — the old
+// defaults produced credentials expired and revoked at creation.
+func TestFixtureLiveCredentialDefaults(t *testing.T) {
+	entity := BuildFixtureEntity(credentialResolved(), "example.com/app")
+
+	defaults := map[string]string{}
+	for _, f := range entity.InsertFields {
+		defaults[f.DBName] = f.TestDefault
+	}
+	if got := defaults["expires_at"]; !strings.Contains(got, "Add(24 * time.Hour)") {
+		t.Errorf("expires_at default = %q, want future time", got)
+	}
+	if got := defaults["revoked_at"]; got != "nil" {
+		t.Errorf("revoked_at default = %q, want nil (tombstones stay NULL)", got)
+	}
+}
+
+// Spec-mode TimeArg encoding must preserve the time expression — wholesale
+// replacement used to silently turn a future expiry back into now().
+func TestSpecEncodeTimeDefaultsPreservesExpression(t *testing.T) {
+	entities := []FixtureEntity{BuildFixtureEntity(credentialResolved(), "example.com/app")}
+	specEncodeTimeDefaults(entities)
+
+	for _, f := range entities[0].InsertFields {
+		if f.DBName == "expires_at" {
+			want := "db.Dialect().TimeArg(time.Now().UTC().Add(24 * time.Hour))"
+			if f.TestDefault != want {
+				t.Errorf("spec expires_at = %q, want %q", f.TestDefault, want)
+			}
+		}
+		if f.DBName == "revoked_at" && f.TestDefault != "nil" {
+			t.Errorf("spec revoked_at = %q, want nil untouched", f.TestDefault)
+		}
+	}
+}
+
+// The generated fixture accepts per-call column overrides (variadic, so
+// existing call sites compile unchanged): override cases for every insert
+// column, a fail-loud unknown-column default, and a PK guard.
+func TestFixtureOverridesEmitted(t *testing.T) {
+	dir := t.TempDir()
+	data := FixtureTemplateData{
+		ModulePath: "example.com/app",
+		Entities:   []FixtureEntity{BuildFixtureEntity(credentialResolved(), "example.com/app")},
+	}
+	if err := GenerateFixtures(data, dir, Options{}); err != nil {
+		t.Fatalf("GenerateFixtures: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "generated.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(out)
+
+	for _, want := range []string{
+		"overrides ...map[string]any",
+		`case "session_token_hash":`,
+		"unknown override column",
+		`the primary key %q cannot be overridden`,
+		"CreateTestSession(t, ctx, db, overrides...)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("generated fixture missing %q", want)
+		}
+	}
+}
+
 // Without a principals entity in the batch, the fallback is "user" — the
 // first value the framework-shipped principals_type_check allows.
 func TestPrincipalInheritanceFixtureFallsBackToUser(t *testing.T) {

--- a/workshop/codegen/generators/fixture_tmpl.go
+++ b/workshop/codegen/generators/fixture_tmpl.go
@@ -37,8 +37,11 @@ var (
 // =============================================================================
 
 // CreateTest{{$e.EntityName}} creates a test {{$e.EntityName}} with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *{{if $.SpecMode}}testsqlite.TestSQLite{{else}}testpgx.TestPGX{{end}}{{range nonSelfRefParents $e.ParentFixtures}}, {{.VarName}} string{{end}}) {{$e.RepoPkg}}.{{$e.EntityName}} {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *{{if $.SpecMode}}testsqlite.TestSQLite{{else}}testpgx.TestPGX{{end}}{{range nonSelfRefParents $e.ParentFixtures}}, {{.VarName}} string{{end}}, overrides ...map[string]any) {{$e.RepoPkg}}.{{$e.EntityName}} {
 	t.Helper()
 	require.NotNil(t, db)
 {{range nonSelfRefParents $e.ParentFixtures}}
@@ -61,15 +64,34 @@ func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *{{if $.S
 	` + "`" + `, {{camel $e.PKColumn}}, {{$e.PrincipalTypeValue}})
 	require.NoError(t, err, "failed to insert principal for {{$e.EntityName}}")
 {{end}}
+	args := []any{
+		{{- range $e.InsertFields}}
+		{{.TestDefault}},
+		{{- end}}
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			{{- range $i, $f := $e.InsertFields}}
+			{{- if eq $f.DBName $e.PKColumn}}
+			case "{{$f.DBName}}":
+				t.Fatalf("CreateTest{{$e.EntityName}}: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			{{- else}}
+			case "{{$f.DBName}}":
+				args[{{$i}}] = val
+			{{- end}}
+			{{- end}}
+			default:
+				t.Fatalf("CreateTest{{$e.EntityName}}: unknown override column %q (insert columns: {{insertCols $e.InsertFields}})", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.{{if $.SpecMode}}DB{{else}}Pool{{end}}.Exec(ctx, ` + "`" + `
 		INSERT INTO {{$e.TableName}} ({{insertCols $e.InsertFields}})
 		VALUES ({{if $.SpecMode}}{{questionArgs (len $e.InsertFields)}}{{else}}{{positionalArgs (len $e.InsertFields)}}{{end}})
-	` + "`" + `,
-		{{- range $e.InsertFields}}
-		{{.TestDefault}},
-		{{- end}}
-	)
+	` + "`" + `, args...)
 	require.NoError(t, err, "failed to insert {{$e.EntityName}}")
 
 {{if $.SpecMode}}	// Retrieve the created record through the dialect-aware scanner —
@@ -100,13 +122,14 @@ func CreateTest{{$e.EntityName}}(t *testing.T, ctx context.Context, db *{{if $.S
 
 // CreateTest{{$e.EntityName}}WithDefaults creates a test {{$e.EntityName}} with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTest{{$e.EntityName}}WithDefaults(t *testing.T, ctx context.Context, db *{{if $.SpecMode}}testsqlite.TestSQLite{{else}}testpgx.TestPGX{{end}}{{range $e.AllExternalParams}}, {{.VarName}} string{{end}}) {{$e.RepoPkg}}.{{$e.EntityName}} {
+// Optional overrides apply to the {{$e.EntityName}} row itself, not its parents.
+func CreateTest{{$e.EntityName}}WithDefaults(t *testing.T, ctx context.Context, db *{{if $.SpecMode}}testsqlite.TestSQLite{{else}}testpgx.TestPGX{{end}}{{range $e.AllExternalParams}}, {{.VarName}} string{{end}}, overrides ...map[string]any) {{$e.RepoPkg}}.{{$e.EntityName}} {
 	t.Helper()
 {{range inBatchParents $e.ParentFixtures}}
 	{{.VarName}}Parent := CreateTest{{.EntityName}}WithDefaults(t, ctx, db{{range .ForwardParams}}, {{.VarName}}{{end}})
 	{{.VarName}} := {{.VarName}}Parent.{{.PKGoName}}
 {{end}}
-	return CreateTest{{$e.EntityName}}(t, ctx, db{{range nonSelfRefParents $e.ParentFixtures}}, {{.VarName}}{{end}})
+	return CreateTest{{$e.EntityName}}(t, ctx, db{{range nonSelfRefParents $e.ParentFixtures}}, {{.VarName}}{{end}}, overrides...)
 }
 {{end}}`
 

--- a/workshop/testing/fixtures/generated.go
+++ b/workshop/testing/fixtures/generated.go
@@ -43,8 +43,11 @@ var (
 // =============================================================================
 
 // CreateTestPrincipal creates a test Principal with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestPrincipal(t *testing.T, ctx context.Context, db *testpgx.TestPGX) principals.Principal {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestPrincipal(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) principals.Principal {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -56,14 +59,28 @@ func CreateTestPrincipal(t *testing.T, ctx context.Context, db *testpgx.TestPGX)
 	principalID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		principalID,
+		"user",
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "principal_id":
+				t.Fatalf("CreateTestPrincipal: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "principal_type":
+				args[1] = val
+			default:
+				t.Fatalf("CreateTestPrincipal: unknown override column %q (insert columns: principal_id, principal_type)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO principals (principal_id, principal_type)
 		VALUES ($1, $2)
-	`,
-		principalID,
-		"user",
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert Principal")
 
 	// Retrieve the created record.
@@ -84,10 +101,11 @@ func CreateTestPrincipal(t *testing.T, ctx context.Context, db *testpgx.TestPGX)
 
 // CreateTestPrincipalWithDefaults creates a test Principal with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestPrincipalWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) principals.Principal {
+// Optional overrides apply to the Principal row itself, not its parents.
+func CreateTestPrincipalWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) principals.Principal {
 	t.Helper()
 
-	return CreateTestPrincipal(t, ctx, db)
+	return CreateTestPrincipal(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -95,8 +113,11 @@ func CreateTestPrincipalWithDefaults(t *testing.T, ctx context.Context, db *test
 // =============================================================================
 
 // CreateTestUser creates a test User with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestUser(t *testing.T, ctx context.Context, db *testpgx.TestPGX) users.User {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestUser(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) users.User {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -116,18 +137,40 @@ func CreateTestUser(t *testing.T, ctx context.Context, db *testpgx.TestPGX) user
 	`, userID, "user")
 	require.NoError(t, err, "failed to insert principal for User")
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO users (user_id, email, display_name, email_verified, last_login_at, record_state)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`,
+	args := []any{
 		userID,
-		"test_"+testUniqueID[:8]+"@example.com",
+		"test_" + testUniqueID[:8] + "@example.com",
 		conversion.Ptr("test_display_name"),
 		false,
 		conversion.Ptr(time.Now().UTC()),
 		"active",
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "user_id":
+				t.Fatalf("CreateTestUser: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "email":
+				args[1] = val
+			case "display_name":
+				args[2] = val
+			case "email_verified":
+				args[3] = val
+			case "last_login_at":
+				args[4] = val
+			case "record_state":
+				args[5] = val
+			default:
+				t.Fatalf("CreateTestUser: unknown override column %q (insert columns: user_id, email, display_name, email_verified, last_login_at, record_state)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO users (user_id, email, display_name, email_verified, last_login_at, record_state)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, args...)
 	require.NoError(t, err, "failed to insert User")
 
 	// Retrieve the created record.
@@ -153,10 +196,11 @@ func CreateTestUser(t *testing.T, ctx context.Context, db *testpgx.TestPGX) user
 
 // CreateTestUserWithDefaults creates a test User with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestUserWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) users.User {
+// Optional overrides apply to the User row itself, not its parents.
+func CreateTestUserWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) users.User {
 	t.Helper()
 
-	return CreateTestUser(t, ctx, db)
+	return CreateTestUser(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -164,8 +208,11 @@ func CreateTestUserWithDefaults(t *testing.T, ctx context.Context, db *testpgx.T
 // =============================================================================
 
 // CreateTestServiceAccount creates a test ServiceAccount with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestServiceAccount(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string, ownerUserID string) serviceaccounts.ServiceAccount {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestServiceAccount(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string, ownerUserID string, overrides ...map[string]any) serviceaccounts.ServiceAccount {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -188,19 +235,43 @@ func CreateTestServiceAccount(t *testing.T, ctx context.Context, db *testpgx.Tes
 	`, serviceAccountID, "user")
 	require.NoError(t, err, "failed to insert principal for ServiceAccount")
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO service_accounts (service_account_id, name, description, creator_principal_id, record_state, act_as_user, owner_user_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`,
+	args := []any{
 		serviceAccountID,
-		"test_name_"+testUniqueID[:8],
+		"test_name_" + testUniqueID[:8],
 		conversion.Ptr("test_description"),
 		creatorPrincipalID,
 		"active",
 		false,
 		ownerUserID,
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "service_account_id":
+				t.Fatalf("CreateTestServiceAccount: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "name":
+				args[1] = val
+			case "description":
+				args[2] = val
+			case "creator_principal_id":
+				args[3] = val
+			case "record_state":
+				args[4] = val
+			case "act_as_user":
+				args[5] = val
+			case "owner_user_id":
+				args[6] = val
+			default:
+				t.Fatalf("CreateTestServiceAccount: unknown override column %q (insert columns: service_account_id, name, description, creator_principal_id, record_state, act_as_user, owner_user_id)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO service_accounts (service_account_id, name, description, creator_principal_id, record_state, act_as_user, owner_user_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, args...)
 	require.NoError(t, err, "failed to insert ServiceAccount")
 
 	// Retrieve the created record.
@@ -227,7 +298,8 @@ func CreateTestServiceAccount(t *testing.T, ctx context.Context, db *testpgx.Tes
 
 // CreateTestServiceAccountWithDefaults creates a test ServiceAccount with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestServiceAccountWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) serviceaccounts.ServiceAccount {
+// Optional overrides apply to the ServiceAccount row itself, not its parents.
+func CreateTestServiceAccountWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) serviceaccounts.ServiceAccount {
 	t.Helper()
 
 	creatorPrincipalIDParent := CreateTestPrincipalWithDefaults(t, ctx, db)
@@ -236,7 +308,7 @@ func CreateTestServiceAccountWithDefaults(t *testing.T, ctx context.Context, db 
 	ownerUserIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	ownerUserID := ownerUserIDParent.UserID
 
-	return CreateTestServiceAccount(t, ctx, db, creatorPrincipalID, ownerUserID)
+	return CreateTestServiceAccount(t, ctx, db, creatorPrincipalID, ownerUserID, overrides...)
 }
 
 // =============================================================================
@@ -244,8 +316,11 @@ func CreateTestServiceAccountWithDefaults(t *testing.T, ctx context.Context, db 
 // =============================================================================
 
 // CreateTestAPIKey creates a test APIKey with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestAPIKey(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentServiceAccountID string) apikeys.APIKey {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestAPIKey(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentServiceAccountID string, overrides ...map[string]any) apikeys.APIKey {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -259,23 +334,55 @@ func CreateTestAPIKey(t *testing.T, ctx context.Context, db *testpgx.TestPGX, pa
 	apiKeyID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO api_keys (api_key_id, parent_service_account_id, name, key_prefix, key_hash, expires_at, last_used_at, last_used_ip, rate_limit_per_minute, record_state, revoked_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-	`,
+	args := []any{
 		apiKeyID,
 		parentServiceAccountID,
-		"test_name_"+testUniqueID[:8],
+		"test_name_" + testUniqueID[:8],
 		testUniqueID[:12],
-		"test_key_hash_"+testUniqueID[:8],
-		conversion.Ptr(time.Now().UTC()),
+		"test_key_hash_" + testUniqueID[:8],
+		conversion.Ptr(time.Now().UTC().Add(24 * time.Hour)),
 		conversion.Ptr(time.Now().UTC()),
 		conversion.Ptr("test_last_used_ip"),
 		conversion.Ptr(0),
 		"active",
-		conversion.Ptr(time.Now().UTC()),
-	)
+		nil,
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "api_key_id":
+				t.Fatalf("CreateTestAPIKey: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "parent_service_account_id":
+				args[1] = val
+			case "name":
+				args[2] = val
+			case "key_prefix":
+				args[3] = val
+			case "key_hash":
+				args[4] = val
+			case "expires_at":
+				args[5] = val
+			case "last_used_at":
+				args[6] = val
+			case "last_used_ip":
+				args[7] = val
+			case "rate_limit_per_minute":
+				args[8] = val
+			case "record_state":
+				args[9] = val
+			case "revoked_at":
+				args[10] = val
+			default:
+				t.Fatalf("CreateTestAPIKey: unknown override column %q (insert columns: api_key_id, parent_service_account_id, name, key_prefix, key_hash, expires_at, last_used_at, last_used_ip, rate_limit_per_minute, record_state, revoked_at)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO api_keys (api_key_id, parent_service_account_id, name, key_prefix, key_hash, expires_at, last_used_at, last_used_ip, rate_limit_per_minute, record_state, revoked_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, args...)
 	require.NoError(t, err, "failed to insert APIKey")
 
 	// Retrieve the created record.
@@ -306,13 +413,14 @@ func CreateTestAPIKey(t *testing.T, ctx context.Context, db *testpgx.TestPGX, pa
 
 // CreateTestAPIKeyWithDefaults creates a test APIKey with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestAPIKeyWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) apikeys.APIKey {
+// Optional overrides apply to the APIKey row itself, not its parents.
+func CreateTestAPIKeyWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) apikeys.APIKey {
 	t.Helper()
 
 	parentServiceAccountIDParent := CreateTestServiceAccountWithDefaults(t, ctx, db)
 	parentServiceAccountID := parentServiceAccountIDParent.ServiceAccountID
 
-	return CreateTestAPIKey(t, ctx, db, parentServiceAccountID)
+	return CreateTestAPIKey(t, ctx, db, parentServiceAccountID, overrides...)
 }
 
 // =============================================================================
@@ -320,8 +428,11 @@ func CreateTestAPIKeyWithDefaults(t *testing.T, ctx context.Context, db *testpgx
 // =============================================================================
 
 // CreateTestEventOutbox creates a test EventOutbox with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestEventOutbox(t *testing.T, ctx context.Context, db *testpgx.TestPGX) eventoutbox.EventOutbox {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestEventOutbox(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) eventoutbox.EventOutbox {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -333,15 +444,31 @@ func CreateTestEventOutbox(t *testing.T, ctx context.Context, db *testpgx.TestPG
 	eventID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		eventID,
+		"test_event_type",
+		json.RawMessage("{}"),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "event_id":
+				t.Fatalf("CreateTestEventOutbox: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "event_type":
+				args[1] = val
+			case "payload":
+				args[2] = val
+			default:
+				t.Fatalf("CreateTestEventOutbox: unknown override column %q (insert columns: event_id, event_type, payload)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO event_outbox (event_id, event_type, payload)
 		VALUES ($1, $2, $3)
-	`,
-		eventID,
-		"test_event_type",
-		json.RawMessage("{}"),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert EventOutbox")
 
 	// Retrieve the created record.
@@ -364,10 +491,11 @@ func CreateTestEventOutbox(t *testing.T, ctx context.Context, db *testpgx.TestPG
 
 // CreateTestEventOutboxWithDefaults creates a test EventOutbox with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestEventOutboxWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) eventoutbox.EventOutbox {
+// Optional overrides apply to the EventOutbox row itself, not its parents.
+func CreateTestEventOutboxWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) eventoutbox.EventOutbox {
 	t.Helper()
 
-	return CreateTestEventOutbox(t, ctx, db)
+	return CreateTestEventOutbox(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -375,8 +503,11 @@ func CreateTestEventOutboxWithDefaults(t *testing.T, ctx context.Context, db *te
 // =============================================================================
 
 // CreateTestGroup creates a test Group with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestGroup(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string) groups.Group {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestGroup(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string, overrides ...map[string]any) groups.Group {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -390,18 +521,40 @@ func CreateTestGroup(t *testing.T, ctx context.Context, db *testpgx.TestPGX, cre
 	groupID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		groupID,
+		"test_name_" + testUniqueID[:8],
+		"test_slug_" + testUniqueID[:8],
+		conversion.Ptr("test_description"),
+		creatorPrincipalID,
+		"active",
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "group_id":
+				t.Fatalf("CreateTestGroup: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "name":
+				args[1] = val
+			case "slug":
+				args[2] = val
+			case "description":
+				args[3] = val
+			case "creator_principal_id":
+				args[4] = val
+			case "record_state":
+				args[5] = val
+			default:
+				t.Fatalf("CreateTestGroup: unknown override column %q (insert columns: group_id, name, slug, description, creator_principal_id, record_state)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO groups (group_id, name, slug, description, creator_principal_id, record_state)
 		VALUES ($1, $2, $3, $4, $5, $6)
-	`,
-		groupID,
-		"test_name_"+testUniqueID[:8],
-		"test_slug_"+testUniqueID[:8],
-		conversion.Ptr("test_description"),
-		creatorPrincipalID,
-		"active",
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert Group")
 
 	// Retrieve the created record.
@@ -427,13 +580,14 @@ func CreateTestGroup(t *testing.T, ctx context.Context, db *testpgx.TestPGX, cre
 
 // CreateTestGroupWithDefaults creates a test Group with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestGroupWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) groups.Group {
+// Optional overrides apply to the Group row itself, not its parents.
+func CreateTestGroupWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) groups.Group {
 	t.Helper()
 
 	creatorPrincipalIDParent := CreateTestPrincipalWithDefaults(t, ctx, db)
 	creatorPrincipalID := creatorPrincipalIDParent.PrincipalID
 
-	return CreateTestGroup(t, ctx, db, creatorPrincipalID)
+	return CreateTestGroup(t, ctx, db, creatorPrincipalID, overrides...)
 }
 
 // =============================================================================
@@ -441,8 +595,11 @@ func CreateTestGroupWithDefaults(t *testing.T, ctx context.Context, db *testpgx.
 // =============================================================================
 
 // CreateTestInvitation creates a test Invitation with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestInvitation(t *testing.T, ctx context.Context, db *testpgx.TestPGX) invitations.Invitation {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestInvitation(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) invitations.Invitation {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -454,27 +611,67 @@ func CreateTestInvitation(t *testing.T, ctx context.Context, db *testpgx.TestPGX
 	invitationID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		invitationID,
+		"test_resource_type",
+		"test_resource_id_" + testUniqueID[:8],
+		"test_relation_" + testUniqueID[:8],
+		"test_identifier_" + testUniqueID[:8],
+		"email",
+		conversion.Ptr("test_resolved_subject_id"),
+		"test_invited_by_" + testUniqueID[:8],
+		"test_token_hash_" + testUniqueID[:8],
+		false,
+		"pending",
+		time.Now().UTC().Add(24 * time.Hour),
+		conversion.Ptr(time.Now().UTC()),
+		"active",
+		conversion.Ptr("test_redirect_url"),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "invitation_id":
+				t.Fatalf("CreateTestInvitation: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "resource_type":
+				args[1] = val
+			case "resource_id":
+				args[2] = val
+			case "relation":
+				args[3] = val
+			case "identifier":
+				args[4] = val
+			case "identifier_type":
+				args[5] = val
+			case "resolved_subject_id":
+				args[6] = val
+			case "invited_by":
+				args[7] = val
+			case "token_hash":
+				args[8] = val
+			case "auto_accept":
+				args[9] = val
+			case "invitation_status":
+				args[10] = val
+			case "expires_at":
+				args[11] = val
+			case "accepted_at":
+				args[12] = val
+			case "record_state":
+				args[13] = val
+			case "redirect_url":
+				args[14] = val
+			default:
+				t.Fatalf("CreateTestInvitation: unknown override column %q (insert columns: invitation_id, resource_type, resource_id, relation, identifier, identifier_type, resolved_subject_id, invited_by, token_hash, auto_accept, invitation_status, expires_at, accepted_at, record_state, redirect_url)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO invitations (invitation_id, resource_type, resource_id, relation, identifier, identifier_type, resolved_subject_id, invited_by, token_hash, auto_accept, invitation_status, expires_at, accepted_at, record_state, redirect_url)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-	`,
-		invitationID,
-		"test_resource_type",
-		"test_resource_id_"+testUniqueID[:8],
-		"test_relation_"+testUniqueID[:8],
-		"test_identifier_"+testUniqueID[:8],
-		"email",
-		conversion.Ptr("test_resolved_subject_id"),
-		"test_invited_by_"+testUniqueID[:8],
-		"test_token_hash_"+testUniqueID[:8],
-		false,
-		"pending",
-		time.Now().UTC(),
-		conversion.Ptr(time.Now().UTC()),
-		"active",
-		conversion.Ptr("test_redirect_url"),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert Invitation")
 
 	// Retrieve the created record.
@@ -509,10 +706,11 @@ func CreateTestInvitation(t *testing.T, ctx context.Context, db *testpgx.TestPGX
 
 // CreateTestInvitationWithDefaults creates a test Invitation with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestInvitationWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) invitations.Invitation {
+// Optional overrides apply to the Invitation row itself, not its parents.
+func CreateTestInvitationWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) invitations.Invitation {
 	t.Helper()
 
-	return CreateTestInvitation(t, ctx, db)
+	return CreateTestInvitation(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -520,8 +718,11 @@ func CreateTestInvitationWithDefaults(t *testing.T, ctx context.Context, db *tes
 // =============================================================================
 
 // CreateTestJobQueue creates a test JobQueue with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestJobQueue(t *testing.T, ctx context.Context, db *testpgx.TestPGX) jobqueue.JobQueue {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestJobQueue(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) jobqueue.JobQueue {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -533,14 +734,10 @@ func CreateTestJobQueue(t *testing.T, ctx context.Context, db *testpgx.TestPGX) 
 	jobID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO job_queue (job_id, event_type, correlation_id, tenant_id, aggregate_type, aggregate_id, payload, occurred_at, status, priority, retry_count, max_retries, worker_name, failure_reason, scheduled_for, staged_at, completed_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-	`,
+	args := []any{
 		jobID,
 		"test_event_type",
-		"test_correlation_id_"+testUniqueID[:8],
+		"test_correlation_id_" + testUniqueID[:8],
 		conversion.Ptr("test_tenant_id"),
 		conversion.Ptr("test_aggregate_type"),
 		conversion.Ptr("test_aggregate_id"),
@@ -555,7 +752,55 @@ func CreateTestJobQueue(t *testing.T, ctx context.Context, db *testpgx.TestPGX) 
 		time.Now().UTC(),
 		conversion.Ptr(time.Now().UTC()),
 		conversion.Ptr(time.Now().UTC()),
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "job_id":
+				t.Fatalf("CreateTestJobQueue: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "event_type":
+				args[1] = val
+			case "correlation_id":
+				args[2] = val
+			case "tenant_id":
+				args[3] = val
+			case "aggregate_type":
+				args[4] = val
+			case "aggregate_id":
+				args[5] = val
+			case "payload":
+				args[6] = val
+			case "occurred_at":
+				args[7] = val
+			case "status":
+				args[8] = val
+			case "priority":
+				args[9] = val
+			case "retry_count":
+				args[10] = val
+			case "max_retries":
+				args[11] = val
+			case "worker_name":
+				args[12] = val
+			case "failure_reason":
+				args[13] = val
+			case "scheduled_for":
+				args[14] = val
+			case "staged_at":
+				args[15] = val
+			case "completed_at":
+				args[16] = val
+			default:
+				t.Fatalf("CreateTestJobQueue: unknown override column %q (insert columns: job_id, event_type, correlation_id, tenant_id, aggregate_type, aggregate_id, payload, occurred_at, status, priority, retry_count, max_retries, worker_name, failure_reason, scheduled_for, staged_at, completed_at)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO job_queue (job_id, event_type, correlation_id, tenant_id, aggregate_type, aggregate_id, payload, occurred_at, status, priority, retry_count, max_retries, worker_name, failure_reason, scheduled_for, staged_at, completed_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+	`, args...)
 	require.NoError(t, err, "failed to insert JobQueue")
 
 	// Retrieve the created record.
@@ -592,10 +837,11 @@ func CreateTestJobQueue(t *testing.T, ctx context.Context, db *testpgx.TestPGX) 
 
 // CreateTestJobQueueWithDefaults creates a test JobQueue with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestJobQueueWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) jobqueue.JobQueue {
+// Optional overrides apply to the JobQueue row itself, not its parents.
+func CreateTestJobQueueWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) jobqueue.JobQueue {
 	t.Helper()
 
-	return CreateTestJobQueue(t, ctx, db)
+	return CreateTestJobQueue(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -603,8 +849,11 @@ func CreateTestJobQueueWithDefaults(t *testing.T, ctx context.Context, db *testp
 // =============================================================================
 
 // CreateTestOauthAccount creates a test OauthAccount with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestOauthAccount(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentUserID string) oauthaccounts.OauthAccount {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestOauthAccount(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentUserID string, overrides ...map[string]any) oauthaccounts.OauthAccount {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -618,27 +867,67 @@ func CreateTestOauthAccount(t *testing.T, ctx context.Context, db *testpgx.TestP
 	oauthAccountID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO oauth_accounts (oauth_account_id, parent_user_id, provider, provider_user_id, provider_email, provider_email_verified, account_verified, access_token, refresh_token, token_expires_at, token_type, scope, id_token, profile_data, linked_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-	`,
+	args := []any{
 		oauthAccountID,
 		parentUserID,
-		"test_provider_"+testUniqueID[:8],
-		"test_provider_user_id_"+testUniqueID[:8],
+		"test_provider_" + testUniqueID[:8],
+		"test_provider_user_id_" + testUniqueID[:8],
 		conversion.Ptr("test_provider_email"),
 		conversion.Ptr(false),
 		false,
 		conversion.Ptr("test_access_token"),
 		conversion.Ptr("test_refresh_token"),
-		conversion.Ptr(time.Now().UTC()),
+		conversion.Ptr(time.Now().UTC().Add(24 * time.Hour)),
 		conversion.Ptr("test_token_type"),
 		conversion.Ptr("test_scope"),
 		conversion.Ptr("test_id_token"),
 		conversion.Ptr(json.RawMessage("{}")),
 		time.Now().UTC(),
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "oauth_account_id":
+				t.Fatalf("CreateTestOauthAccount: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "parent_user_id":
+				args[1] = val
+			case "provider":
+				args[2] = val
+			case "provider_user_id":
+				args[3] = val
+			case "provider_email":
+				args[4] = val
+			case "provider_email_verified":
+				args[5] = val
+			case "account_verified":
+				args[6] = val
+			case "access_token":
+				args[7] = val
+			case "refresh_token":
+				args[8] = val
+			case "token_expires_at":
+				args[9] = val
+			case "token_type":
+				args[10] = val
+			case "scope":
+				args[11] = val
+			case "id_token":
+				args[12] = val
+			case "profile_data":
+				args[13] = val
+			case "linked_at":
+				args[14] = val
+			default:
+				t.Fatalf("CreateTestOauthAccount: unknown override column %q (insert columns: oauth_account_id, parent_user_id, provider, provider_user_id, provider_email, provider_email_verified, account_verified, access_token, refresh_token, token_expires_at, token_type, scope, id_token, profile_data, linked_at)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO oauth_accounts (oauth_account_id, parent_user_id, provider, provider_user_id, provider_email, provider_email_verified, account_verified, access_token, refresh_token, token_expires_at, token_type, scope, id_token, profile_data, linked_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+	`, args...)
 	require.NoError(t, err, "failed to insert OauthAccount")
 
 	// Retrieve the created record.
@@ -673,13 +962,14 @@ func CreateTestOauthAccount(t *testing.T, ctx context.Context, db *testpgx.TestP
 
 // CreateTestOauthAccountWithDefaults creates a test OauthAccount with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestOauthAccountWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) oauthaccounts.OauthAccount {
+// Optional overrides apply to the OauthAccount row itself, not its parents.
+func CreateTestOauthAccountWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) oauthaccounts.OauthAccount {
 	t.Helper()
 
 	parentUserIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	parentUserID := parentUserIDParent.UserID
 
-	return CreateTestOauthAccount(t, ctx, db, parentUserID)
+	return CreateTestOauthAccount(t, ctx, db, parentUserID, overrides...)
 }
 
 // =============================================================================
@@ -687,8 +977,11 @@ func CreateTestOauthAccountWithDefaults(t *testing.T, ctx context.Context, db *t
 // =============================================================================
 
 // CreateTestRebacRelationship creates a test RebacRelationship with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestRebacRelationship(t *testing.T, ctx context.Context, db *testpgx.TestPGX) rebacrelationships.RebacRelationship {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestRebacRelationship(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) rebacrelationships.RebacRelationship {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -700,19 +993,43 @@ func CreateTestRebacRelationship(t *testing.T, ctx context.Context, db *testpgx.
 	relationshipID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		relationshipID,
+		"test_resource_type",
+		"test_resource_id_" + testUniqueID[:8],
+		"test_relation_" + testUniqueID[:8],
+		"test_subject_type",
+		"test_subject_id_" + testUniqueID[:8],
+		conversion.Ptr("test_subject_relation"),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "relationship_id":
+				t.Fatalf("CreateTestRebacRelationship: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "resource_type":
+				args[1] = val
+			case "resource_id":
+				args[2] = val
+			case "relation":
+				args[3] = val
+			case "subject_type":
+				args[4] = val
+			case "subject_id":
+				args[5] = val
+			case "subject_relation":
+				args[6] = val
+			default:
+				t.Fatalf("CreateTestRebacRelationship: unknown override column %q (insert columns: relationship_id, resource_type, resource_id, relation, subject_type, subject_id, subject_relation)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO rebac_relationships (relationship_id, resource_type, resource_id, relation, subject_type, subject_id, subject_relation)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`,
-		relationshipID,
-		"test_resource_type",
-		"test_resource_id_"+testUniqueID[:8],
-		"test_relation_"+testUniqueID[:8],
-		"test_subject_type",
-		"test_subject_id_"+testUniqueID[:8],
-		conversion.Ptr("test_subject_relation"),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert RebacRelationship")
 
 	// Retrieve the created record.
@@ -738,10 +1055,11 @@ func CreateTestRebacRelationship(t *testing.T, ctx context.Context, db *testpgx.
 
 // CreateTestRebacRelationshipWithDefaults creates a test RebacRelationship with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestRebacRelationshipWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) rebacrelationships.RebacRelationship {
+// Optional overrides apply to the RebacRelationship row itself, not its parents.
+func CreateTestRebacRelationshipWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) rebacrelationships.RebacRelationship {
 	t.Helper()
 
-	return CreateTestRebacRelationship(t, ctx, db)
+	return CreateTestRebacRelationship(t, ctx, db, overrides...)
 }
 
 // =============================================================================
@@ -749,8 +1067,11 @@ func CreateTestRebacRelationshipWithDefaults(t *testing.T, ctx context.Context, 
 // =============================================================================
 
 // CreateTestRebacRelationshipMetadata creates a test RebacRelationshipMetadata with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestRebacRelationshipMetadata(t *testing.T, ctx context.Context, db *testpgx.TestPGX, relationshipID string) rebacrelationshipmetadata.RebacRelationshipMetadata {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestRebacRelationshipMetadata(t *testing.T, ctx context.Context, db *testpgx.TestPGX, relationshipID string, overrides ...map[string]any) rebacrelationshipmetadata.RebacRelationshipMetadata {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -761,14 +1082,28 @@ func CreateTestRebacRelationshipMetadata(t *testing.T, ctx context.Context, db *
 	require.NoError(t, err)
 	_ = testUniqueID
 
+	args := []any{
+		relationshipID,
+		json.RawMessage("{}"),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "relationship_id":
+				t.Fatalf("CreateTestRebacRelationshipMetadata: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "metadata":
+				args[1] = val
+			default:
+				t.Fatalf("CreateTestRebacRelationshipMetadata: unknown override column %q (insert columns: relationship_id, metadata)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO rebac_relationship_metadata (relationship_id, metadata)
 		VALUES ($1, $2)
-	`,
-		relationshipID,
-		json.RawMessage("{}"),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert RebacRelationshipMetadata")
 
 	// Retrieve the created record.
@@ -790,13 +1125,14 @@ func CreateTestRebacRelationshipMetadata(t *testing.T, ctx context.Context, db *
 
 // CreateTestRebacRelationshipMetadataWithDefaults creates a test RebacRelationshipMetadata with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestRebacRelationshipMetadataWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) rebacrelationshipmetadata.RebacRelationshipMetadata {
+// Optional overrides apply to the RebacRelationshipMetadata row itself, not its parents.
+func CreateTestRebacRelationshipMetadataWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) rebacrelationshipmetadata.RebacRelationshipMetadata {
 	t.Helper()
 
 	relationshipIDParent := CreateTestRebacRelationshipWithDefaults(t, ctx, db)
 	relationshipID := relationshipIDParent.RelationshipID
 
-	return CreateTestRebacRelationshipMetadata(t, ctx, db, relationshipID)
+	return CreateTestRebacRelationshipMetadata(t, ctx, db, relationshipID, overrides...)
 }
 
 // =============================================================================
@@ -804,8 +1140,11 @@ func CreateTestRebacRelationshipMetadataWithDefaults(t *testing.T, ctx context.C
 // =============================================================================
 
 // CreateTestSecurityEvent creates a test SecurityEvent with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestSecurityEvent(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string) securityevents.SecurityEvent {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestSecurityEvent(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string, overrides ...map[string]any) securityevents.SecurityEvent {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -819,11 +1158,7 @@ func CreateTestSecurityEvent(t *testing.T, ctx context.Context, db *testpgx.Test
 	eventID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO security_events (event_id, user_id, event_type, event_status, event_details, ip_address, user_agent)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`,
+	args := []any{
 		eventID,
 		userID,
 		"test_event_type",
@@ -831,7 +1166,35 @@ func CreateTestSecurityEvent(t *testing.T, ctx context.Context, db *testpgx.Test
 		conversion.Ptr(json.RawMessage("{}")),
 		conversion.Ptr("test_ip_address"),
 		conversion.Ptr("test_user_agent"),
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "event_id":
+				t.Fatalf("CreateTestSecurityEvent: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "user_id":
+				args[1] = val
+			case "event_type":
+				args[2] = val
+			case "event_status":
+				args[3] = val
+			case "event_details":
+				args[4] = val
+			case "ip_address":
+				args[5] = val
+			case "user_agent":
+				args[6] = val
+			default:
+				t.Fatalf("CreateTestSecurityEvent: unknown override column %q (insert columns: event_id, user_id, event_type, event_status, event_details, ip_address, user_agent)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO security_events (event_id, user_id, event_type, event_status, event_details, ip_address, user_agent)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, args...)
 	require.NoError(t, err, "failed to insert SecurityEvent")
 
 	// Retrieve the created record.
@@ -857,13 +1220,14 @@ func CreateTestSecurityEvent(t *testing.T, ctx context.Context, db *testpgx.Test
 
 // CreateTestSecurityEventWithDefaults creates a test SecurityEvent with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestSecurityEventWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) securityevents.SecurityEvent {
+// Optional overrides apply to the SecurityEvent row itself, not its parents.
+func CreateTestSecurityEventWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) securityevents.SecurityEvent {
 	t.Helper()
 
 	userIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	userID := userIDParent.UserID
 
-	return CreateTestSecurityEvent(t, ctx, db, userID)
+	return CreateTestSecurityEvent(t, ctx, db, userID, overrides...)
 }
 
 // =============================================================================
@@ -871,8 +1235,11 @@ func CreateTestSecurityEventWithDefaults(t *testing.T, ctx context.Context, db *
 // =============================================================================
 
 // CreateTestSession creates a test Session with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestSession(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentUserID string) sessions.Session {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestSession(t *testing.T, ctx context.Context, db *testpgx.TestPGX, parentUserID string, overrides ...map[string]any) sessions.Session {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -886,23 +1253,55 @@ func CreateTestSession(t *testing.T, ctx context.Context, db *testpgx.TestPGX, p
 	sessionID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
-	// Insert directly via SQL (bypassing repository for test isolation).
-	_, err = db.Pool.Exec(ctx, `
-		INSERT INTO sessions (session_id, parent_user_id, session_token_hash, refresh_token_hash, rotation_count, last_rotation_at, previous_refresh_token_hash, expires_at, last_used_at, user_agent, ip_address)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-	`,
+	args := []any{
 		sessionID,
 		parentUserID,
-		"test_session_token_hash_"+testUniqueID[:8],
+		"test_session_token_hash_" + testUniqueID[:8],
 		conversion.Ptr("test_refresh_token_hash"),
 		conversion.Ptr(0),
 		conversion.Ptr(time.Now().UTC()),
 		conversion.Ptr("test_previous_refresh_token_hash"),
-		time.Now().UTC(),
+		time.Now().UTC().Add(24 * time.Hour),
 		time.Now().UTC(),
 		conversion.Ptr("test_user_agent"),
 		conversion.Ptr("test_ip_address"),
-	)
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "session_id":
+				t.Fatalf("CreateTestSession: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "parent_user_id":
+				args[1] = val
+			case "session_token_hash":
+				args[2] = val
+			case "refresh_token_hash":
+				args[3] = val
+			case "rotation_count":
+				args[4] = val
+			case "last_rotation_at":
+				args[5] = val
+			case "previous_refresh_token_hash":
+				args[6] = val
+			case "expires_at":
+				args[7] = val
+			case "last_used_at":
+				args[8] = val
+			case "user_agent":
+				args[9] = val
+			case "ip_address":
+				args[10] = val
+			default:
+				t.Fatalf("CreateTestSession: unknown override column %q (insert columns: session_id, parent_user_id, session_token_hash, refresh_token_hash, rotation_count, last_rotation_at, previous_refresh_token_hash, expires_at, last_used_at, user_agent, ip_address)", col)
+			}
+		}
+	}
+
+	// Insert directly via SQL (bypassing repository for test isolation).
+	_, err = db.Pool.Exec(ctx, `
+		INSERT INTO sessions (session_id, parent_user_id, session_token_hash, refresh_token_hash, rotation_count, last_rotation_at, previous_refresh_token_hash, expires_at, last_used_at, user_agent, ip_address)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, args...)
 	require.NoError(t, err, "failed to insert Session")
 
 	// Retrieve the created record.
@@ -933,13 +1332,14 @@ func CreateTestSession(t *testing.T, ctx context.Context, db *testpgx.TestPGX, p
 
 // CreateTestSessionWithDefaults creates a test Session with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestSessionWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) sessions.Session {
+// Optional overrides apply to the Session row itself, not its parents.
+func CreateTestSessionWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) sessions.Session {
 	t.Helper()
 
 	parentUserIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	parentUserID := parentUserIDParent.UserID
 
-	return CreateTestSession(t, ctx, db, parentUserID)
+	return CreateTestSession(t, ctx, db, parentUserID, overrides...)
 }
 
 // =============================================================================
@@ -947,8 +1347,11 @@ func CreateTestSessionWithDefaults(t *testing.T, ctx context.Context, db *testpg
 // =============================================================================
 
 // CreateTestTenant creates a test Tenant with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestTenant(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string) tenants.Tenant {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestTenant(t *testing.T, ctx context.Context, db *testpgx.TestPGX, creatorPrincipalID string, overrides ...map[string]any) tenants.Tenant {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -962,18 +1365,40 @@ func CreateTestTenant(t *testing.T, ctx context.Context, db *testpgx.TestPGX, cr
 	tenantID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		tenantID,
+		"test_name_" + testUniqueID[:8],
+		"test_slug_" + testUniqueID[:8],
+		conversion.Ptr("test_description"),
+		creatorPrincipalID,
+		"active",
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "tenant_id":
+				t.Fatalf("CreateTestTenant: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "name":
+				args[1] = val
+			case "slug":
+				args[2] = val
+			case "description":
+				args[3] = val
+			case "creator_principal_id":
+				args[4] = val
+			case "record_state":
+				args[5] = val
+			default:
+				t.Fatalf("CreateTestTenant: unknown override column %q (insert columns: tenant_id, name, slug, description, creator_principal_id, record_state)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO tenants (tenant_id, name, slug, description, creator_principal_id, record_state)
 		VALUES ($1, $2, $3, $4, $5, $6)
-	`,
-		tenantID,
-		"test_name_"+testUniqueID[:8],
-		"test_slug_"+testUniqueID[:8],
-		conversion.Ptr("test_description"),
-		creatorPrincipalID,
-		"active",
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert Tenant")
 
 	// Retrieve the created record.
@@ -999,13 +1424,14 @@ func CreateTestTenant(t *testing.T, ctx context.Context, db *testpgx.TestPGX, cr
 
 // CreateTestTenantWithDefaults creates a test Tenant with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestTenantWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) tenants.Tenant {
+// Optional overrides apply to the Tenant row itself, not its parents.
+func CreateTestTenantWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) tenants.Tenant {
 	t.Helper()
 
 	creatorPrincipalIDParent := CreateTestPrincipalWithDefaults(t, ctx, db)
 	creatorPrincipalID := creatorPrincipalIDParent.PrincipalID
 
-	return CreateTestTenant(t, ctx, db, creatorPrincipalID)
+	return CreateTestTenant(t, ctx, db, creatorPrincipalID, overrides...)
 }
 
 // =============================================================================
@@ -1013,8 +1439,11 @@ func CreateTestTenantWithDefaults(t *testing.T, ctx context.Context, db *testpgx
 // =============================================================================
 
 // CreateTestUserPassword creates a test UserPassword with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestUserPassword(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string) userpasswords.UserPassword {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestUserPassword(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string, overrides ...map[string]any) userpasswords.UserPassword {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -1025,16 +1454,34 @@ func CreateTestUserPassword(t *testing.T, ctx context.Context, db *testpgx.TestP
 	require.NoError(t, err)
 	_ = testUniqueID
 
+	args := []any{
+		userID,
+		"test_password_hash_" + testUniqueID[:8],
+		time.Now().UTC(),
+		false,
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "user_id":
+				t.Fatalf("CreateTestUserPassword: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "password_hash":
+				args[1] = val
+			case "password_changed_at":
+				args[2] = val
+			case "password_verified":
+				args[3] = val
+			default:
+				t.Fatalf("CreateTestUserPassword: unknown override column %q (insert columns: user_id, password_hash, password_changed_at, password_verified)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO user_passwords (user_id, password_hash, password_changed_at, password_verified)
 		VALUES ($1, $2, $3, $4)
-	`,
-		userID,
-		"test_password_hash_"+testUniqueID[:8],
-		time.Now().UTC(),
-		false,
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert UserPassword")
 
 	// Retrieve the created record.
@@ -1058,13 +1505,14 @@ func CreateTestUserPassword(t *testing.T, ctx context.Context, db *testpgx.TestP
 
 // CreateTestUserPasswordWithDefaults creates a test UserPassword with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestUserPasswordWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) userpasswords.UserPassword {
+// Optional overrides apply to the UserPassword row itself, not its parents.
+func CreateTestUserPasswordWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) userpasswords.UserPassword {
 	t.Helper()
 
 	userIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	userID := userIDParent.UserID
 
-	return CreateTestUserPassword(t, ctx, db, userID)
+	return CreateTestUserPassword(t, ctx, db, userID, overrides...)
 }
 
 // =============================================================================
@@ -1072,8 +1520,11 @@ func CreateTestUserPasswordWithDefaults(t *testing.T, ctx context.Context, db *t
 // =============================================================================
 
 // CreateTestVerificationCode creates a test VerificationCode with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestVerificationCode(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string) verificationcodes.VerificationCode {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestVerificationCode(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string, overrides ...map[string]any) verificationcodes.VerificationCode {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -1087,20 +1538,46 @@ func CreateTestVerificationCode(t *testing.T, ctx context.Context, db *testpgx.T
 	codeID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		codeID,
+		"test_identifier_" + testUniqueID[:8],
+		"test_code_hash_" + testUniqueID[:8],
+		"test_purpose_" + testUniqueID[:8],
+		userID,
+		conversion.Ptr(json.RawMessage("{}")),
+		0,
+		time.Now().UTC().Add(24 * time.Hour),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "code_id":
+				t.Fatalf("CreateTestVerificationCode: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "identifier":
+				args[1] = val
+			case "code_hash":
+				args[2] = val
+			case "purpose":
+				args[3] = val
+			case "user_id":
+				args[4] = val
+			case "data":
+				args[5] = val
+			case "attempt_count":
+				args[6] = val
+			case "expires_at":
+				args[7] = val
+			default:
+				t.Fatalf("CreateTestVerificationCode: unknown override column %q (insert columns: code_id, identifier, code_hash, purpose, user_id, data, attempt_count, expires_at)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO verification_codes (code_id, identifier, code_hash, purpose, user_id, data, attempt_count, expires_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	`,
-		codeID,
-		"test_identifier_"+testUniqueID[:8],
-		"test_code_hash_"+testUniqueID[:8],
-		"test_purpose_"+testUniqueID[:8],
-		userID,
-		conversion.Ptr(json.RawMessage("{}")),
-		0,
-		time.Now().UTC(),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert VerificationCode")
 
 	// Retrieve the created record.
@@ -1127,13 +1604,14 @@ func CreateTestVerificationCode(t *testing.T, ctx context.Context, db *testpgx.T
 
 // CreateTestVerificationCodeWithDefaults creates a test VerificationCode with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestVerificationCodeWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) verificationcodes.VerificationCode {
+// Optional overrides apply to the VerificationCode row itself, not its parents.
+func CreateTestVerificationCodeWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) verificationcodes.VerificationCode {
 	t.Helper()
 
 	userIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	userID := userIDParent.UserID
 
-	return CreateTestVerificationCode(t, ctx, db, userID)
+	return CreateTestVerificationCode(t, ctx, db, userID, overrides...)
 }
 
 // =============================================================================
@@ -1141,8 +1619,11 @@ func CreateTestVerificationCodeWithDefaults(t *testing.T, ctx context.Context, d
 // =============================================================================
 
 // CreateTestVerificationToken creates a test VerificationToken with valid test data via direct SQL INSERT.
-// Bypasses the repository layer for test isolation.
-func CreateTestVerificationToken(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string) verificationtokens.VerificationToken {
+// Bypasses the repository layer for test isolation. Optional overrides
+// replace the generated default for the named insert columns — e.g.
+// seeding a credential row whose hash must match a real token. Overriding
+// the primary key or an unknown column fails the test.
+func CreateTestVerificationToken(t *testing.T, ctx context.Context, db *testpgx.TestPGX, userID string, overrides ...map[string]any) verificationtokens.VerificationToken {
 	t.Helper()
 	require.NotNil(t, db)
 
@@ -1156,18 +1637,40 @@ func CreateTestVerificationToken(t *testing.T, ctx context.Context, db *testpgx.
 	tokenID, err := cryptids.GenerateID()
 	require.NoError(t, err)
 
+	args := []any{
+		tokenID,
+		"test_token_hash_" + testUniqueID[:8],
+		"test_purpose_" + testUniqueID[:8],
+		"test_identifier_" + testUniqueID[:8],
+		userID,
+		time.Now().UTC().Add(24 * time.Hour),
+	}
+	for _, ov := range overrides {
+		for col, val := range ov {
+			switch col {
+			case "token_id":
+				t.Fatalf("CreateTestVerificationToken: the primary key %q cannot be overridden — it drives the fixture's read-back", col)
+			case "token_hash":
+				args[1] = val
+			case "purpose":
+				args[2] = val
+			case "identifier":
+				args[3] = val
+			case "user_id":
+				args[4] = val
+			case "expires_at":
+				args[5] = val
+			default:
+				t.Fatalf("CreateTestVerificationToken: unknown override column %q (insert columns: token_id, token_hash, purpose, identifier, user_id, expires_at)", col)
+			}
+		}
+	}
+
 	// Insert directly via SQL (bypassing repository for test isolation).
 	_, err = db.Pool.Exec(ctx, `
 		INSERT INTO verification_tokens (token_id, token_hash, purpose, identifier, user_id, expires_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
-	`,
-		tokenID,
-		"test_token_hash_"+testUniqueID[:8],
-		"test_purpose_"+testUniqueID[:8],
-		"test_identifier_"+testUniqueID[:8],
-		userID,
-		time.Now().UTC(),
-	)
+	`, args...)
 	require.NoError(t, err, "failed to insert VerificationToken")
 
 	// Retrieve the created record.
@@ -1192,11 +1695,12 @@ func CreateTestVerificationToken(t *testing.T, ctx context.Context, db *testpgx.
 
 // CreateTestVerificationTokenWithDefaults creates a test VerificationToken with auto-created FK dependencies.
 // FK dependencies whose parent table is outside this generation batch are required as parameters.
-func CreateTestVerificationTokenWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX) verificationtokens.VerificationToken {
+// Optional overrides apply to the VerificationToken row itself, not its parents.
+func CreateTestVerificationTokenWithDefaults(t *testing.T, ctx context.Context, db *testpgx.TestPGX, overrides ...map[string]any) verificationtokens.VerificationToken {
 	t.Helper()
 
 	userIDParent := CreateTestUserWithDefaults(t, ctx, db)
 	userID := userIDParent.UserID
 
-	return CreateTestVerificationToken(t, ctx, db, userID)
+	return CreateTestVerificationToken(t, ctx, db, userID, overrides...)
 }

--- a/workshop/testing/testauth/seed_integration_test.go
+++ b/workshop/testing/testauth/seed_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+// The Phase A acceptance test for the authenticated e2e stack: a session
+// row seeded through the generated fixtures with a REAL token hash must
+// authenticate through the engine end to end — fixture overrides +
+// authentication.HashToken + AuthenticatorWithRepositories are the three
+// primitives the generated e2e bootstrap composes.
+package testauth_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gopernicus/gopernicus/core/auth/authentication"
+	"github.com/gopernicus/gopernicus/core/auth/authentication/satisfiers"
+	"github.com/gopernicus/gopernicus/core/repositories/auth/sessions"
+	"github.com/gopernicus/gopernicus/core/repositories/auth/sessions/sessionspgx"
+	"github.com/gopernicus/gopernicus/core/repositories/auth/users"
+	"github.com/gopernicus/gopernicus/core/repositories/auth/users/userspgx"
+	"github.com/gopernicus/gopernicus/infrastructure/database/postgres/pgxdb"
+	"github.com/gopernicus/gopernicus/workshop/testing/fixtures"
+	"github.com/gopernicus/gopernicus/workshop/testing/testauth"
+	"github.com/gopernicus/gopernicus/workshop/testing/testpgx"
+	"github.com/stretchr/testify/require"
+)
+
+func migrateTestDB(ctx context.Context, pool *pgxdb.Pool) error {
+	return pgxdb.RunMigrations(ctx, pool, os.DirFS(projectRoot()), "workshop/migrations/primary")
+}
+
+func projectRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}
+
+func TestSeededSessionAuthenticates(t *testing.T) {
+	ctx := context.Background()
+	db := testpgx.SetupTestPGX(t, ctx, testpgx.WithMigrations(migrateTestDB))
+	log := slog.New(slog.DiscardHandler)
+
+	usersRepo := users.NewRepository(userspgx.NewStore(log, db.Pool))
+	sessionsRepo := sessions.NewRepository(sessionspgx.NewStore(log, db.Pool))
+	repos := authentication.NewRepositories(
+		satisfiers.NewUserSatisfier(usersRepo),
+		nil,
+		satisfiers.NewSessionSatisfier(sessionsRepo),
+		nil,
+		nil,
+	)
+	auth, signer := testauth.AuthenticatorWithRepositories("seedtest", repos)
+
+	user := fixtures.CreateTestUserWithDefaults(t, ctx, db)
+
+	// Seed a session whose stored hash matches a real minted token — the
+	// override path; the generic default hash can never authenticate.
+	token := testauth.MintAccessToken(signer, user.UserID)
+	hash, err := authentication.HashToken(token)
+	require.NoError(t, err)
+	fixtures.CreateTestSession(t, ctx, db, user.UserID, map[string]any{
+		"session_token_hash": hash,
+	})
+
+	gotUser, gotSession, err := auth.AuthenticateSession(ctx, token)
+	require.NoError(t, err, "seeded session must authenticate end to end")
+	require.Equal(t, user.UserID, gotUser.UserID)
+	require.Equal(t, user.UserID, gotSession.UserID)
+
+	// Controls use distinct users: same-user tokens minted within the same
+	// second are byte-identical JWTs (second-resolution exp) and would
+	// collide with the seeded row.
+
+	// A valid JWT with no matching session row must fail — proves the row
+	// lookup is real, not signature-only.
+	orphanUser := fixtures.CreateTestUserWithDefaults(t, ctx, db)
+	orphan := testauth.MintAccessToken(signer, orphanUser.UserID)
+	_, _, err = auth.AuthenticateSession(ctx, orphan)
+	require.Error(t, err, "token without a seeded session row must not authenticate")
+
+	// The fixture's generic dummy hash must not authenticate — the exact
+	// gap the overrides close.
+	dummyUser := fixtures.CreateTestUserWithDefaults(t, ctx, db)
+	fixtures.CreateTestSession(t, ctx, db, dummyUser.UserID)
+	dummy := testauth.MintAccessToken(signer, dummyUser.UserID)
+	_, _, err = auth.AuthenticateSession(ctx, dummy)
+	require.Error(t, err, "dummy-hash fixture session must not match a real token")
+}

--- a/workshop/testing/testauth/testauth.go
+++ b/workshop/testing/testauth/testauth.go
@@ -35,6 +35,28 @@ func Authenticator(name string) (*authentication.Authenticator, *golangjwt.Signe
 	return auth, signer
 }
 
+// AuthenticatorWithRepositories returns an authenticator over real
+// repositories, for harnesses that exercise the database-backed
+// authentication modes — user sessions and API keys — where a seeded
+// credential row must be looked up for real. Pair with the generated
+// fixtures' column overrides and authentication.HashToken to seed rows
+// the engine will match:
+//
+//	token := testauth.MintAccessToken(signer, user.UserID)
+//	hash, _ := authentication.HashToken(token)
+//	fixtures.CreateTestSession(t, ctx, db, user.UserID,
+//		map[string]any{"session_token_hash": hash})
+func AuthenticatorWithRepositories(name string, repos authentication.Repositories) (*authentication.Authenticator, *golangjwt.Signer) {
+	signer, err := golangjwt.NewSigner(testSecret)
+	if err != nil {
+		panic("testauth: build signer: " + err.Error())
+	}
+	auth := authentication.NewAuthenticator(name, repos, nil, signer, nil, authentication.Config{
+		AccessTokenExpiry: time.Hour,
+	})
+	return auth, signer
+}
+
 // MintAccessToken signs a valid access token carrying the given user id —
 // the claim AuthenticateJWT reads. Use distinct ids to act as different
 // principals in isolation tests.


### PR DESCRIPTION
## Summary

v0.4 item 4 phase A (per the ratified plan): everything the authenticated e2e generator (phase B) needs to mint credentials that actually authenticate.

**The gap:** generated fixtures insert dummy hashes (`test_session_token_hash_*`) that can never pass the engine's hash lookup, and — worse — sessions/API keys were created **expired at birth** (`expires_at = now()`) and API keys **revoked at birth** (`revoked_at` filled because it's nullable). No seeded credential could ever authenticate.

**Phase A primitives:**
1. **Fixture column overrides** — `CreateTestX(t, ctx, db, …, map[string]any{"session_token_hash": hash})`. Variadic, so every existing call site compiles unchanged. Unknown columns and the PK fail loud. `WithDefaults` forwards overrides to the entity row only.
2. **`authentication.HashToken`** exported — the canonical credential hash, so harnesses can't drift from the engine.
3. **`testauth.AuthenticatorWithRepositories`** — real-repo authenticator for the DB-backed modes.

**Fixture default fixes (general, not auth-specific):** `*expires_at` → 24h future; tombstone columns (`revoked_at`, `deleted_at`, `archived_at`, `disabled_at`, `removed_at`) → NULL; spec-mode `TimeArg` wrap now preserves the inner time expression (wholesale replacement would have silently reverted the future expiry in sqlite mode).

## Verification
- **Acceptance test against real postgres** (`workshop/testing/testauth/seed_integration_test.go`): fixture-seeded session with a real token hash authenticates end-to-end through `AuthenticateSession`; an orphan JWT fails (lookup is real); a dummy-hash fixture session fails (the exact gap closed). Writing it also re-confirmed the second-resolution JWT determinism quirk — controls use distinct users.
- Full `-tags=integration` suite green with the new defaults; all vets green; generate-twice determinism clean; framework fixtures regenerated and committed.

Phase B (next): the e2e generator stops skipping authenticated routes and selects credentials per route auth mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)