### PR TITLE
feat(codegen): authenticated e2e suites — phase B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
   `authentication.HashToken` is exported so harnesses seed credential
   rows the engine will match; `testauth.AuthenticatorWithRepositories`
   wires the real database-backed authentication modes.
+- Authenticated e2e suites (phase B): the bridge e2e generator no longer
+  skips authenticated routes. Suites whose routes authenticate as `user`
+  or `any` run with a minted JWT (no DB rows); `user_session` routes get
+  a session row seeded with the real token hash (pgx mode). Authenticated
+  suites also gain an anonymous-401 probe. Still skipped, each with its
+  printed reason: authorize-gated routes (ReBAC seeding is phase C),
+  `service_account` routes, mixed user/service-account suites, and
+  `user_session` on spec-mode databases.
+- `testauth.MemoryStore` — an in-memory `authorization.Storer`;
+  `testauth.Authorizer()` now uses it instead of a nil store (generated
+  hard-delete handlers call `DeleteResourceRelationships` even on
+  bridges with no authorize-gated routes — the nil store panicked the
+  server). `AuthorizerWithStore` returns a seedable pair for
+  authorization tests.
+- `testhttp.Client.Anonymous()` — a credential-less client against the
+  same server, for rejection probes alongside an authenticated client.
 
 ### Fixed
 - Generated fixture defaults now produce live rows: `*expires_at` columns

--- a/workshop/codegen/generators/bridge_e2e_gen.go
+++ b/workshop/codegen/generators/bridge_e2e_gen.go
@@ -77,6 +77,28 @@ type BridgeE2EData struct {
 	// returning unfiltered results (P2).
 	StringFilterParams []string
 	OtherProbeParams   []string
+
+	// AuthMode selects the credential the suite drives routes with:
+	// "" (anonymous), "jwt" (user/any fast path — a minted token, no DB
+	// rows), or "session" (user_session — a session row seeded with a real
+	// token hash; pgx only). service_account and authorize-gated routes
+	// still skip the suite, each with its own printed reason.
+	AuthMode string
+
+	// BridgeAuthEnabled mirrors the bridge's AuthEnabled flag: NewBridge
+	// takes authenticator+authorizer parameters when set, regardless of
+	// which routes authenticate.
+	BridgeAuthEnabled bool
+
+	// CreateAuthed / GetAuthed gate the anonymous-401 probe — when the
+	// suite runs authenticated, one unauthenticated request must still be
+	// rejected, proving enforcement is on in this exact stack.
+	CreateAuthed bool
+	GetAuthed    bool
+
+	// ModulePath derives the session-mode auth imports (project repos,
+	// satisfiers) in the generated file.
+	ModulePath string
 }
 
 // GenerateBridgeE2E emits light e2e tests for a bridged entity hosted by a
@@ -208,16 +230,26 @@ func buildBridgeE2EData(data BridgeTemplateData, resolved *ResolvedFile, moduleP
 		break
 	}
 
-	// The e2e probes drive routes anonymously (POST → 201, GET → 200). If
-	// any route the suite exercises requires authentication or authorization,
-	// those calls would 401/403 instead — skip e2e for the entity until an
-	// authenticated stack exists (see the security suite for auth coverage).
-	for _, r := range data.Routes {
+	// Route auth requirements are evaluated per SUITE route below — only
+	// the routes the probes actually exercise decide the credential.
+	type routeAuth struct {
+		mode       string // "" | "user" | "service_account" | "user_session" | "any"
+		authorized bool
+		method     string
+		path       string
+	}
+	suiteAuth := map[string]routeAuth{}
+	recordAuth := func(funcName string, r BridgeRoute) {
+		ra := routeAuth{method: r.Method, path: r.Path}
 		for _, m := range r.MiddlewareChain {
-			if m.Authenticate != "" || m.Authorize != nil {
-				return BridgeE2EData{}, fmt.Sprintf("route %s %s requires auth — e2e probes drive routes anonymously", r.Method, r.Path)
+			if m.Authenticate != "" {
+				ra.mode = m.Authenticate
+			}
+			if m.Authorize != nil {
+				ra.authorized = true
 			}
 		}
+		suiteAuth[funcName] = ra
 	}
 
 	pkParam := "{" + resolved.PKColumn + "}"
@@ -226,6 +258,7 @@ func buildBridgeE2EData(data BridgeTemplateData, resolved *ResolvedFile, moduleP
 		case "Create":
 			if r.Method == "POST" && !strings.Contains(r.Path, "{") {
 				e2e.CreatePath = r.Path
+				recordAuth("Create", r)
 				for _, m := range r.MiddlewareChain {
 					if m.MaxBodySize > 0 {
 						e2e.CreateMaxBodySize = m.MaxBodySize
@@ -237,24 +270,64 @@ func buildBridgeE2EData(data BridgeTemplateData, resolved *ResolvedFile, moduleP
 			if expr, ok := pkOnlyPathExpr(r.Path, pkParam); ok {
 				e2e.HasGet = true
 				e2e.GetPathExpr = expr
+				recordAuth("Get", r)
 			}
 		case "List":
 			if r.Method == "GET" && !strings.Contains(r.Path, "{") {
 				e2e.HasList = true
 				e2e.ListPath = r.Path
+				recordAuth("List", r)
 			}
 		case "Delete":
 			if expr, ok := pkOnlyPathExpr(r.Path, pkParam); ok {
 				e2e.HasDelete = true
 				e2e.DeletePathExpr = expr
+				recordAuth("Delete", r)
 			}
 		case "Update":
 			if expr, ok := pkOnlyPathExpr(r.Path, pkParam); ok {
 				e2e.HasUpdate = true
 				e2e.UpdatePathExpr = expr
+				recordAuth("Update", r)
 			}
 		}
 	}
+
+	// Pick the suite credential from the exercised routes' auth modes.
+	// A session-backed JWT satisfies user, any, and user_session; a plain
+	// minted JWT satisfies user and any. service_account routes need an
+	// API-key-wired stack (project-specific GetByHash) and authorize-gated
+	// routes need ReBAC seeding — both still skip, each saying why.
+	var needSession, needUser, needServiceAccount bool
+	for _, ra := range suiteAuth {
+		if ra.authorized {
+			return BridgeE2EData{}, fmt.Sprintf("route %s %s requires authorization — ReBAC seeding is not yet generated", ra.method, ra.path)
+		}
+		switch ra.mode {
+		case "user_session":
+			needSession = true
+		case "user", "any":
+			needUser = true
+		case "service_account":
+			needServiceAccount = true
+		}
+	}
+	switch {
+	case needServiceAccount && (needUser || needSession):
+		return BridgeE2EData{}, "routes mix service_account and user credentials — per-route credential switching is not yet generated"
+	case needServiceAccount:
+		return BridgeE2EData{}, "service_account routes need an API-key-wired stack — not yet generated"
+	case needSession && specMode:
+		return BridgeE2EData{}, "user_session routes need the pgx auth stack — not available in spec mode"
+	case needSession:
+		e2e.AuthMode = "session"
+	case needUser:
+		e2e.AuthMode = "jwt"
+	}
+	e2e.BridgeAuthEnabled = data.AuthEnabled
+	e2e.ModulePath = modulePath
+	e2e.CreateAuthed = suiteAuth["Create"].mode != ""
+	e2e.GetAuthed = suiteAuth["Get"].mode != ""
 
 	// Pick a settable, non-server-set string update field for the update
 	// mass-assignment probe (SEC1 already strips record_state/ownership from

--- a/workshop/codegen/generators/bridge_e2e_gen_test.go
+++ b/workshop/codegen/generators/bridge_e2e_gen_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/gopernicus/gopernicus/workshop/codegen/schema"
 )
 
 // fullE2EData returns BridgeE2EData with every optional probe enabled, so a
@@ -111,6 +113,141 @@ func TestBridgeE2ETemplatesRenderGofmtClean(t *testing.T) {
 				t.Errorf("specMode=%v: e2e bootstrap still inlines the go.mod walk", specMode)
 			}
 		}
+	}
+}
+
+// Authenticated modes (phase B): jwt drives routes with a minted token and
+// no extra wiring; session wires real user/session repos and seeds a session
+// row whose hash matches the minted token. Both render gofmt-clean with the
+// auth-enabled NewBridge signature and the anonymous-401 probe.
+func TestBridgeE2EAuthModesRender(t *testing.T) {
+	jwt := fullE2EData(false)
+	jwt.AuthMode = "jwt"
+	jwt.BridgeAuthEnabled = true
+	jwt.CreateAuthed = true
+	jwt.GetAuthed = true
+	jwt.ModulePath = "github.com/x/app"
+
+	out := renderTemplateString(t, "bridge_e2e", bridgeE2EGeneratedTemplate, jwt)
+	for _, want := range []string{
+		`testauth.Authenticator("e2etest")`,
+		`client.SetBearerToken(testauth.MintAccessToken(signer, "e2e-test-user"))`,
+		"authenticator, testauth.Authorizer())",
+		"TestE2EThingRequiresAuthentication",
+		"client.Anonymous()",
+		"RequireStatus(t, 401)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("jwt mode: missing %q", want)
+		}
+	}
+	if strings.Contains(out, "AuthenticatorWithRepositories") {
+		t.Error("jwt mode must not wire repositories")
+	}
+
+	session := jwt
+	session.AuthMode = "session"
+	out = renderTemplateString(t, "bridge_e2e", bridgeE2EGeneratedTemplate, session)
+	for _, want := range []string{
+		"testauth.AuthenticatorWithRepositories",
+		"satisfiers.NewUserSatisfier",
+		"satisfiers.NewSessionSatisfier",
+		"authentication.HashToken(token)",
+		`"session_token_hash": tokenHash`,
+		"fixtures.CreateTestUserWithDefaults",
+		`"github.com/x/app/core/repositories/auth/sessions/sessionspgx"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("session mode: missing %q", want)
+		}
+	}
+
+	// Auth-enabled bridge with anonymous suite routes still passes the
+	// authenticator/authorizer constructor args, mints nothing.
+	anon := fullE2EData(false)
+	anon.BridgeAuthEnabled = true
+	out = renderTemplateString(t, "bridge_e2e", bridgeE2EGeneratedTemplate, anon)
+	if !strings.Contains(out, "authenticator, _ := testauth.Authenticator") {
+		t.Error("auth-enabled anonymous suite must still construct the authenticator")
+	}
+	if strings.Contains(out, "SetBearerToken") {
+		t.Error("anonymous suite must not set a credential")
+	}
+}
+
+// Suite-route auth requirements drive credential selection and the
+// remaining skip classes.
+func TestBuildBridgeE2EAuthSelection(t *testing.T) {
+	route := func(funcName, method, path, mode string, authorize bool) BridgeRoute {
+		r := BridgeRoute{FuncName: funcName, Method: method, Path: path}
+		if mode != "" {
+			r.MiddlewareChain = append(r.MiddlewareChain, MiddlewareEntry{Authenticate: mode})
+		}
+		if authorize {
+			r.MiddlewareChain = append(r.MiddlewareChain, MiddlewareEntry{Authorize: &AuthorizeEntry{}})
+		}
+		return r
+	}
+	base := func(routes ...BridgeRoute) BridgeTemplateData {
+		return BridgeTemplateData{
+			BridgePackage: "thingsbridge",
+			EntityName:    "Thing",
+			AuthEnabled:   true,
+			CreateQueries: []BridgeCreateQuery{{FuncName: "Create", Fields: []BridgeField{{DBName: "title", GoName: "Title", IsString: true}}}},
+			Routes:        routes,
+		}
+	}
+	resolved := &ResolvedFile{
+		TableName: "things",
+		PKColumn:  "id",
+		AllColumns: []schema.ColumnInfo{
+			{Name: "id", DBType: "text", GoType: "string", IsPrimaryKey: true},
+			{Name: "title", DBType: "text", GoType: "string"},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		routes   []BridgeRoute
+		wantMode string
+		wantSkip string
+	}{
+		{"anonymous", []BridgeRoute{route("Create", "POST", "/things", "", false)}, "", ""},
+		{"user → jwt", []BridgeRoute{route("Create", "POST", "/things", "user", false)}, "jwt", ""},
+		{"any → jwt", []BridgeRoute{route("Create", "POST", "/things", "any", false)}, "jwt", ""},
+		{"user_session → session", []BridgeRoute{route("Create", "POST", "/things", "user_session", false)}, "session", ""},
+		{"authorize skips", []BridgeRoute{route("Create", "POST", "/things", "user", true)}, "", "requires authorization"},
+		{"service_account skips", []BridgeRoute{route("Create", "POST", "/things", "service_account", false)}, "", "API-key-wired"},
+		{"mixed skips", []BridgeRoute{
+			route("Create", "POST", "/things", "service_account", false),
+			route("Get", "GET", "/things/{id}", "user", false),
+		}, "", "mix service_account and user"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e2e, skip := buildBridgeE2EData(base(tc.routes...), resolved, "github.com/x/app", "primary", false)
+			if tc.wantSkip != "" {
+				if !strings.Contains(skip, tc.wantSkip) {
+					t.Fatalf("skip = %q, want containing %q", skip, tc.wantSkip)
+				}
+				return
+			}
+			if skip != "" {
+				t.Fatalf("unexpected skip: %s", skip)
+			}
+			if e2e.AuthMode != tc.wantMode {
+				t.Errorf("AuthMode = %q, want %q", e2e.AuthMode, tc.wantMode)
+			}
+			if !e2e.BridgeAuthEnabled {
+				t.Error("BridgeAuthEnabled must mirror data.AuthEnabled")
+			}
+		})
+	}
+
+	// session + spec mode skips: the sqlite stack has no auth wiring.
+	_, skip := buildBridgeE2EData(base(route("Create", "POST", "/things", "user_session", false)), resolved, "github.com/x/app", "litedb", true)
+	if !strings.Contains(skip, "spec mode") {
+		t.Errorf("spec-mode session skip = %q", skip)
 	}
 }
 

--- a/workshop/codegen/generators/bridge_e2e_tmpl.go
+++ b/workshop/codegen/generators/bridge_e2e_tmpl.go
@@ -30,8 +30,20 @@ import (
 
 	"{{.RepoImport}}"
 	"{{.StoreImport}}"
+{{- if eq .AuthMode "session"}}
+	"{{.ModulePath}}/core/auth/authentication/satisfiers"
+	"{{.ModulePath}}/core/repositories/auth/sessions"
+	"{{.ModulePath}}/core/repositories/auth/sessions/sessionspgx"
+	"{{.ModulePath}}/core/repositories/auth/users"
+	"{{.ModulePath}}/core/repositories/auth/users/userspgx"
+
+	"github.com/gopernicus/gopernicus/core/auth/authentication"
+{{- end}}
 
 	"github.com/gopernicus/gopernicus/sdk/logger"
+{{- if .BridgeAuthEnabled}}
+	"github.com/gopernicus/gopernicus/workshop/testing/testauth"
+{{- end}}
 	"github.com/gopernicus/gopernicus/workshop/testing/testhttp"
 {{- if not .SpecMode}}
 	"github.com/gopernicus/gopernicus/workshop/testing/testpgx"
@@ -40,7 +52,7 @@ import (
 {{- if .SpecMode}}
 	"github.com/gopernicus/gopernicus/workshop/testing/testsqlite"
 {{- end}}
-{{- if .FKSeeds}}
+{{- if or .FKSeeds (eq .AuthMode "session")}}
 	"{{.FixtureImport}}"
 {{- end}}
 )
@@ -74,9 +86,47 @@ func setupE2EServer(t *testing.T) (*testhttp.Client, e2eDB) {
 	store := {{.StorePkg}}.NewStore(logger.NewNoop(), db.Pool)
 {{- end}}
 	repo := {{.RepoPkg}}.NewRepository({{.RepoPkg}}.NewCacheStore(store, nil))
+{{- if .BridgeAuthEnabled}}
+{{- if eq .AuthMode "session"}}
+	usersRepo := users.NewRepository(users.NewCacheStore(userspgx.NewStore(logger.NewNoop(), db.Pool), nil))
+	sessionsRepo := sessions.NewRepository(sessions.NewCacheStore(sessionspgx.NewStore(logger.NewNoop(), db.Pool), nil))
+	authenticator, signer := testauth.AuthenticatorWithRepositories("e2etest", authentication.NewRepositories(
+		satisfiers.NewUserSatisfier(usersRepo),
+		nil,
+		satisfiers.NewSessionSatisfier(sessionsRepo),
+		nil,
+		nil,
+	))
+{{- else if eq .AuthMode "jwt"}}
+	authenticator, signer := testauth.Authenticator("e2etest")
+{{- else}}
+	authenticator, _ := testauth.Authenticator("e2etest")
+{{- end}}
+	bridge := NewBridge(logger.NewNoop(), repo, testserver.NewRateLimiter(), authenticator, testauth.Authorizer())
+{{- else}}
 	bridge := NewBridge(logger.NewNoop(), repo, testserver.NewRateLimiter())
+{{- end}}
 
-	return testserver.ServeBridge(t, bridge), db
+	client := testserver.ServeBridge(t, bridge)
+{{- if eq .AuthMode "jwt"}}
+
+	// The exercised routes authenticate via the JWT fast path (signature
+	// only) — a minted token needs no database rows.
+	client.SetBearerToken(testauth.MintAccessToken(signer, "e2e-test-user"))
+{{- else if eq .AuthMode "session"}}
+
+	// user_session routes recheck the session row: seed a session whose
+	// stored hash matches the real minted token.
+	user := {{.FixturePkg}}.CreateTestUserWithDefaults(t, ctx, db)
+	token := testauth.MintAccessToken(signer, user.UserID)
+	tokenHash, err := authentication.HashToken(token)
+	require.NoError(t, err)
+	{{.FixturePkg}}.CreateTestSession(t, ctx, db, user.UserID, map[string]any{
+		"session_token_hash": tokenHash,
+	})
+	client.SetBearerToken(token)
+{{- end}}
+	return client, db
 }
 
 // seededCreate{{.EntityName}}Request builds a valid create request, populating
@@ -97,6 +147,21 @@ func seededCreate{{.EntityName}}Request(t *testing.T, db e2eDB) Create{{.EntityN
 {{- end}}
 }
 
+{{if or .CreateAuthed (and .HasGet .GetAuthed)}}
+// The suite runs authenticated — one anonymous request must still be
+// rejected, proving enforcement is live in this exact stack.
+func TestE2E{{.EntityName}}RequiresAuthentication(t *testing.T) {
+	client, db := setupE2EServer(t)
+	anon := client.Anonymous()
+{{- if .CreateAuthed}}
+	anon.Post(t, "{{.CreatePath}}", seededCreate{{.EntityName}}Request(t, db)).RequireStatus(t, 401)
+{{- else}}
+	_ = db
+	id := "{{.NotFoundID}}"
+	anon.Get(t, {{.GetPathExpr}}).RequireStatus(t, 401)
+{{- end}}
+}
+{{end}}
 func TestE2E{{.EntityName}}CreateAndGet(t *testing.T) {
 	client, db := setupE2EServer(t)
 

--- a/workshop/testing/testauth/memorystore.go
+++ b/workshop/testing/testauth/memorystore.go
@@ -1,0 +1,224 @@
+package testauth
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gopernicus/gopernicus/core/auth/authorization"
+	"github.com/gopernicus/gopernicus/sdk/fop"
+)
+
+var _ authorization.Storer = (*MemoryStore)(nil)
+
+// tuple is one relationship: subject --relation--> resource.
+type tuple struct {
+	resourceType, resourceID, relation, subjectType, subjectID string
+}
+
+// MemoryStore is an in-memory authorization.Storer for test stacks: the
+// authorizer reads and writes plain tuples, no database. Group expansion is
+// direct-match only and the recursive lookups walk the tuple slice — enough
+// for generated test suites seeding a handful of relationships, not a ReBAC
+// engine. The zero value is not usable; call NewMemoryStore.
+type MemoryStore struct {
+	mu     sync.Mutex
+	tuples []tuple
+}
+
+// NewMemoryStore returns an empty in-memory authorization store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{}
+}
+
+// Seed inserts one relationship — the test-side convenience for granting a
+// subject a relation before driving a route.
+func (s *MemoryStore) Seed(resourceType, resourceID, relation, subjectType, subjectID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tuples = append(s.tuples, tuple{resourceType, resourceID, relation, subjectType, subjectID})
+}
+
+func (s *MemoryStore) CheckRelationWithGroupExpansion(_ context.Context, resourceType, resourceID, relation, subjectType, subjectID string) (bool, error) {
+	return s.exists(resourceType, resourceID, relation, subjectType, subjectID), nil
+}
+
+func (s *MemoryStore) GetRelationTargets(_ context.Context, resourceType, resourceID, relation string) ([]authorization.RelationTarget, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var targets []authorization.RelationTarget
+	for _, t := range s.tuples {
+		if t.resourceType == resourceType && t.resourceID == resourceID && t.relation == relation {
+			targets = append(targets, authorization.RelationTarget{SubjectType: t.subjectType, SubjectID: t.subjectID})
+		}
+	}
+	return targets, nil
+}
+
+func (s *MemoryStore) CheckRelationExists(_ context.Context, resourceType, resourceID, relation, subjectType, subjectID string) (bool, error) {
+	return s.exists(resourceType, resourceID, relation, subjectType, subjectID), nil
+}
+
+func (s *MemoryStore) CheckBatchDirect(_ context.Context, resourceType string, resourceIDs []string, relation, subjectType, subjectID string) (map[string]bool, error) {
+	result := make(map[string]bool, len(resourceIDs))
+	for _, id := range resourceIDs {
+		result[id] = s.exists(resourceType, id, relation, subjectType, subjectID)
+	}
+	return result, nil
+}
+
+func (s *MemoryStore) CreateRelationships(_ context.Context, relationships []authorization.CreateRelationship) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range relationships {
+		s.tuples = append(s.tuples, tuple{r.ResourceType, r.ResourceID, r.Relation, r.SubjectType, r.SubjectID})
+	}
+	return nil
+}
+
+func (s *MemoryStore) DeleteResourceRelationships(_ context.Context, resourceType, resourceID string) error {
+	s.filter(func(t tuple) bool {
+		return !(t.resourceType == resourceType && t.resourceID == resourceID)
+	})
+	return nil
+}
+
+func (s *MemoryStore) DeleteRelationship(_ context.Context, resourceType, resourceID, relation, subjectType, subjectID string) error {
+	s.filter(func(t tuple) bool {
+		return t != tuple{resourceType, resourceID, relation, subjectType, subjectID}
+	})
+	return nil
+}
+
+func (s *MemoryStore) DeleteByResourceAndSubject(_ context.Context, resourceType, resourceID, subjectType, subjectID string) error {
+	s.filter(func(t tuple) bool {
+		return !(t.resourceType == resourceType && t.resourceID == resourceID &&
+			t.subjectType == subjectType && t.subjectID == subjectID)
+	})
+	return nil
+}
+
+func (s *MemoryStore) CountByResourceAndRelation(_ context.Context, resourceType, resourceID, relation string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, t := range s.tuples {
+		if t.resourceType == resourceType && t.resourceID == resourceID && t.relation == relation {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (s *MemoryStore) ListRelationshipsBySubject(_ context.Context, subjectType, subjectID string, _ authorization.SubjectRelationshipFilter, _ fop.Order, _ fop.PageStringCursor) ([]authorization.SubjectRelationship, fop.Pagination, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []authorization.SubjectRelationship
+	for _, t := range s.tuples {
+		if t.subjectType == subjectType && t.subjectID == subjectID {
+			out = append(out, authorization.SubjectRelationship{
+				ResourceType: t.resourceType, ResourceID: t.resourceID, Relation: t.relation,
+			})
+		}
+	}
+	return out, fop.Pagination{}, nil
+}
+
+func (s *MemoryStore) ListRelationshipsByResource(_ context.Context, resourceType, resourceID string, _ authorization.ResourceRelationshipFilter, _ fop.Order, _ fop.PageStringCursor) ([]authorization.ResourceRelationship, fop.Pagination, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []authorization.ResourceRelationship
+	for _, t := range s.tuples {
+		if t.resourceType == resourceType && t.resourceID == resourceID {
+			out = append(out, authorization.ResourceRelationship{
+				SubjectType: t.subjectType, SubjectID: t.subjectID, Relation: t.relation,
+			})
+		}
+	}
+	return out, fop.Pagination{}, nil
+}
+
+func (s *MemoryStore) LookupResourceIDs(_ context.Context, resourceType string, relations []string, subjectType, subjectID string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := map[string]bool{}
+	var ids []string
+	for _, t := range s.tuples {
+		if t.resourceType != resourceType || t.subjectType != subjectType || t.subjectID != subjectID {
+			continue
+		}
+		for _, rel := range relations {
+			if t.relation == rel && !seen[t.resourceID] {
+				seen[t.resourceID] = true
+				ids = append(ids, t.resourceID)
+			}
+		}
+	}
+	return ids, nil
+}
+
+func (s *MemoryStore) LookupResourceIDsByRelationTarget(_ context.Context, resourceType, relation, targetType string, targetIDs []string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := map[string]bool{}
+	for _, id := range targetIDs {
+		want[id] = true
+	}
+	seen := map[string]bool{}
+	var ids []string
+	for _, t := range s.tuples {
+		if t.resourceType == resourceType && t.relation == relation && t.subjectType == targetType && want[t.subjectID] && !seen[t.resourceID] {
+			seen[t.resourceID] = true
+			ids = append(ids, t.resourceID)
+		}
+	}
+	return ids, nil
+}
+
+func (s *MemoryStore) LookupDescendantResourceIDs(_ context.Context, resourceType, relation, subjectType string, rootIDs []string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	frontier := map[string]bool{}
+	for _, id := range rootIDs {
+		frontier[id] = true
+	}
+	found := map[string]bool{}
+	for changed := true; changed; {
+		changed = false
+		for _, t := range s.tuples {
+			if t.resourceType == resourceType && t.relation == relation && t.subjectType == subjectType &&
+				frontier[t.subjectID] && !found[t.resourceID] {
+				found[t.resourceID] = true
+				frontier[t.resourceID] = true
+				changed = true
+			}
+		}
+	}
+	ids := make([]string, 0, len(found))
+	for id := range found {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (s *MemoryStore) exists(resourceType, resourceID, relation, subjectType, subjectID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.tuples {
+		if t == (tuple{resourceType, resourceID, relation, subjectType, subjectID}) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MemoryStore) filter(keep func(tuple) bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := s.tuples[:0]
+	for _, t := range s.tuples {
+		if keep(t) {
+			kept = append(kept, t)
+		}
+	}
+	s.tuples = kept
+}

--- a/workshop/testing/testauth/testauth.go
+++ b/workshop/testing/testauth/testauth.go
@@ -68,10 +68,20 @@ func MintAccessToken(signer *golangjwt.Signer, userID string) string {
 	return token
 }
 
-// Authorizer returns an authorizer over an empty schema. Authentication is
-// enforced ahead of authorization, so the security suite's rejection probes
-// never reach the (nil) store; isolation tests that need real authorization
-// supply their own schema/store.
+// Authorizer returns an authorizer over an empty schema and an empty
+// in-memory store. The store is real (never nil): generated handlers call
+// relationship writes outside permission checks — hard-delete cleanup runs
+// DeleteResourceRelationships even when no route authorizes — and a nil
+// store panics the server. Isolation tests that need real authorization
+// supply their own schema/store, or seed this one via AuthorizerWithStore.
 func Authorizer() *authorization.Authorizer {
-	return authorization.NewAuthorizer(nil, authorization.Schema{}, authorization.Config{})
+	return authorization.NewAuthorizer(NewMemoryStore(), authorization.Schema{}, authorization.Config{})
+}
+
+// AuthorizerWithStore returns an authorizer over the given schema backed by
+// a seedable in-memory store — grant a relation with store.Seed(...) before
+// driving an authorize-gated route.
+func AuthorizerWithStore(schema authorization.Schema) (*authorization.Authorizer, *MemoryStore) {
+	store := NewMemoryStore()
+	return authorization.NewAuthorizer(store, schema, authorization.Config{}), store
 }

--- a/workshop/testing/testhttp/client.go
+++ b/workshop/testing/testhttp/client.go
@@ -36,6 +36,13 @@ func New(baseURL string) *Client {
 	}
 }
 
+// Anonymous returns a fresh client against the same server with no
+// credentials — for probes asserting that unauthenticated requests are
+// rejected while the main client stays authenticated.
+func (c *Client) Anonymous() *Client {
+	return New(c.baseURL)
+}
+
 // SetBearerToken sets the Authorization header for all subsequent requests.
 func (c *Client) SetBearerToken(token string) {
 	c.headers.Set("Authorization", "Bearer "+token)


### PR DESCRIPTION
## Summary

v0.4 item 4 phase B: the bridge e2e generator stops skipping authenticated routes. Per-suite credential selection from the exercised routes' auth modes:

| Route mode | Credential |
|---|---|
| `user` / `any` | Minted JWT (signature fast path — zero DB rows) |
| `user_session` | Real user/session repos + a session row seeded with the real token hash via the phase-A fixture overrides (pgx) |
| authorize-gated | Still skips: "ReBAC seeding is not yet generated" (phase C) |
| `service_account` | Still skips: needs the project-specific API-key stack |
| mixed user + service_account | Still skips: per-route credential switching not yet generated |
| `user_session` on spec mode | Still skips: no sqlite auth stack |

Authenticated suites gain an **anonymous-401 probe** (`testhttp.Client.Anonymous()`), proving enforcement is live in the same stack the other probes drive.

**Latent panic found and fixed:** the first authenticated hard-delete ever driven through a testauth stack panicked the server — generated delete handlers call `DeleteResourceRelationships` even on bridges with no authorize-gated routes, and `testauth.Authorizer()` wrapped a **nil store**. The security suite never caught it because it only asserts 401s. `testauth.MemoryStore` (full in-memory `authorization.Storer`) fixes it, and `AuthorizerWithStore` returns a seedable pair that phase C builds on.

## Verification (synthetic consumer, full fidelity)

Built a scratch full-features project through the real consumer loop (`init --features=… → db migrate → db reflect → generate → go test -tags e2e`, local framework via replace) with two custom entities: `notes` (`authenticate: user`) and `memos` (`authenticate: user_session`). **All nine probes pass for both modes against real postgres via testcontainers**, including the 401 probes and the delete that exposed the nil-store panic. Plus: generator unit tests for mode selection (7 cases) and template rendering (jwt/session/anonymous-with-auth-enabled), full framework vets/unit suite, regenerate-twice determinism.

## Honest findings

1. **Segovia gains zero suites from phase B alone.** Every authenticated route in segovia (and in the framework's own feature bridges) is also ReBAC-authorized — `recentaccessbridge`, the lone authenticate-only candidate, has `routes: []` (fully hand-written). The plan's "expected to unskip a chunk of segovia" was wrong about the distribution; the acceptance criterion lands with **phase C**, for which this PR lays the seeding mechanism (`MemoryStore.Seed`).
2. **Two pre-existing scaffold gaps** in the `--features=authentication`-only combination surfaced during verification (composition root missing the authorizer arg in `NewBridges` calls; domain composite referencing an undefined `AuthSchema`). Untested upstream because S11 uses all features and S1 uses none. Not fixed here — filed in the commit message for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)