### PR TITLE
docs: cut the v0.4.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## Unreleased
+## v0.4.0 — 2026-06-12
 
 ### Added
 - `gopernicus doctor --json` — machine-readable health output with a stable


### PR DESCRIPTION
Retitles the Unreleased section to v0.4.0 — 2026-06-12 ahead of tagging. Content covers PRs #30–#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)