### PR TITLE
docs: cut the v0.4.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## Unreleased
+## v0.4.1 — 2026-06-12
 
 ### Fixed
 - **Authorization resource-type derivation (production behavior change).**


### PR DESCRIPTION
Retitles Unreleased → v0.4.1 ahead of tagging (PR #38 content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)