### PR TITLE
docs: cut the v0.5.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## Unreleased
+## v0.5.0 — 2026-06-12
 
 ### Added
 - **Generated TypeScript client** (v0.5 item 1): `gopernicus generate`


### PR DESCRIPTION
Retitles Unreleased → v0.5.0 (TS client #40, rebac bulk-delete fix, SSE bridge #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)