### PR TITLE
fix(sdk/web): SSE survives middleware wrappers and server WriteTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
+## Unreleased
+
+### Fixed
+- **SSE streams died under production middleware and server timeouts** —
+  two bugs found by the live segovia demo, invisible to httptest:
+  (1) the request logger's `statusWriter` hid `http.Flusher`, so any
+  wrapped SSE handler 500'd "streaming not supported" — it now
+  implements `Unwrap` and SSE flushes via `http.ResponseController`;
+  (2) the server's `WriteTimeout` arms at request start, killing every
+  stream at its first post-deadline frame (segovia: exactly 25.001s, the
+  first heartbeat) — `SSEStream` now extends the write deadline per
+  frame (4× heartbeat; 2m without one). `StreamWriter` gets the same
+  treatment. Regression tests pin heartbeat delivery and SSE through a
+  logger-wrapped chain.
+
+### Consumer actions
+- [ ] Repin + redeploy if you mounted ssebridge on v0.5.0 — streams
+      longer than your server WriteTimeout require this fix.
+
 ## v0.5.0 — 2026-06-12
 
 ### Added

--- a/bridge/events/ssebridge/hub_test.go
+++ b/bridge/events/ssebridge/hub_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gopernicus/gopernicus/bridge/events/ssebridge"
+	"github.com/gopernicus/gopernicus/bridge/transit/httpmid"
 	"github.com/gopernicus/gopernicus/core/auth/authorization"
 	"github.com/gopernicus/gopernicus/infrastructure/events"
 	"github.com/gopernicus/gopernicus/infrastructure/events/memorybus"
@@ -58,6 +59,10 @@ func serve(t *testing.T, hub *ssebridge.Hub) (string, string) {
 
 	bridge := ssebridge.New(quietLog(), hub, authenticator, authorizer, nil)
 	handler := web.NewWebHandler()
+	// Production stacks wrap every request in logging middleware whose
+	// statusWriter must stay flushable (segovia's live demo 500'd with
+	// "streaming not supported" before Unwrap + ResponseController).
+	handler.Use(httpmid.Logger(quietLog()))
 	bridge.AddHttpRoutes(handler.Group("/events"))
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)

--- a/bridge/transit/httpmid/logger.go
+++ b/bridge/transit/httpmid/logger.go
@@ -67,6 +67,12 @@ func (w *statusWriter) WriteHeader(code int) {
 	w.ResponseWriter.WriteHeader(code)
 }
 
+// Unwrap exposes the wrapped writer for http.ResponseController, so
+// streaming handlers (SSE) can reach Flush through the middleware chain.
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (w *statusWriter) Write(b []byte) (int, error) {
 	if !w.wroteHeader {
 		w.wroteHeader = true

--- a/sdk/web/capture.go
+++ b/sdk/web/capture.go
@@ -47,6 +47,7 @@ func (rc *ResponseCapture) Unwrap() http.ResponseWriter {
 	return rc.ResponseWriter
 }
 
+
 // Flush implements http.Flusher if the underlying writer supports it.
 func (rc *ResponseCapture) Flush() {
 	if f, ok := rc.ResponseWriter.(http.Flusher); ok {

--- a/sdk/web/sse.go
+++ b/sdk/web/sse.go
@@ -37,6 +37,16 @@ func WithHeartbeat(d time.Duration) SSEOption {
 	return func(s *SSEStream) { s.heartbeat = d }
 }
 
+// writeWindow is the per-write deadline extension: generous relative to
+// the heartbeat so a healthy stream never trips it, finite so a dead
+// client's connection is reclaimed.
+func (s *SSEStream) writeWindow() time.Duration {
+	if s.heartbeat > 0 {
+		return s.heartbeat * 4
+	}
+	return 2 * time.Minute
+}
+
 // NewSSEStream creates an SSE stream that reads events from the channel.
 func NewSSEStream(events <-chan SSEEvent, opts ...SSEOption) *SSEStream {
 	s := &SSEStream{events: events}
@@ -54,14 +64,26 @@ func (s *SSEStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	// ResponseController reaches Flush through middleware wrappers that
+	// implement Unwrap — a bare type assertion fails under any wrapping
+	// middleware (request loggers etc.).
+	rc := http.NewResponseController(w)
+
+	// Long-lived streams outlive the server's WriteTimeout: the deadline
+	// arms at request start and every write after it fails, killing the
+	// stream at the first post-deadline frame. Extend it per write
+	// instead; falls back silently when the connection doesn't support
+	// deadlines (e.g. some test recorders).
+	extendDeadline := func() {
+		_ = rc.SetWriteDeadline(time.Now().Add(s.writeWindow()))
+	}
+	extendDeadline()
+
+	w.WriteHeader(http.StatusOK)
+	if err := rc.Flush(); err != nil {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
 
 	var heartbeat <-chan time.Time
 	if s.heartbeat > 0 {
@@ -76,24 +98,28 @@ func (s *SSEStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 
 		case <-heartbeat:
+			extendDeadline()
 			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
 				return
 			}
-			flusher.Flush()
+			if err := rc.Flush(); err != nil {
+				return
+			}
 
 		case event, ok := <-s.events:
 			if !ok {
 				return
 			}
 
-			if err := writeSSEEvent(w, flusher, event); err != nil {
+			extendDeadline()
+			if err := writeSSEEvent(w, rc, event); err != nil {
 				return
 			}
 		}
 	}
 }
 
-func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event SSEEvent) error {
+func writeSSEEvent(w http.ResponseWriter, rc *http.ResponseController, event SSEEvent) error {
 	if event.Event != "" {
 		if _, err := fmt.Fprintf(w, "event: %s\n", event.Event); err != nil {
 			return err
@@ -130,6 +156,5 @@ func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event SSEEvent) 
 		return err
 	}
 
-	flusher.Flush()
-	return nil
+	return rc.Flush()
 }

--- a/sdk/web/sse_heartbeat_test.go
+++ b/sdk/web/sse_heartbeat_test.go
@@ -1,0 +1,40 @@
+package web_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gopernicus/gopernicus/sdk/web"
+)
+
+func TestSSEHeartbeat(t *testing.T) {
+	ch := make(chan web.SSEEvent)
+	srv := httptest.NewServer(web.NewSSEStream(ch, web.WithHeartbeat(50*time.Millisecond)))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	buf := make([]byte, 256)
+	deadline := time.Now().Add(2 * time.Second)
+	var got strings.Builder
+	for time.Now().Before(deadline) {
+		n, err := resp.Body.Read(buf)
+		got.Write(buf[:n])
+		if strings.Contains(got.String(), ": ping") {
+			t.Log("ping received")
+			return
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+	t.Fatalf("no ping within deadline; got %q", got.String())
+}

--- a/sdk/web/stream.go
+++ b/sdk/web/stream.go
@@ -25,20 +25,18 @@ import (
 //	})
 type StreamWriter struct {
 	w       http.ResponseWriter
-	flusher http.Flusher
+	rc      *http.ResponseController
 	started bool
 }
 
-// NewStreamWriter creates a StreamWriter. Returns nil if the ResponseWriter
-// does not support flushing (required for streaming).
+// NewStreamWriter creates a StreamWriter. Flushing goes through
+// http.ResponseController, which reaches the real Flusher through
+// middleware wrappers implementing Unwrap; an unflushable writer surfaces
+// as an error on the first Send.
 func NewStreamWriter(w http.ResponseWriter) *StreamWriter {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		return nil
-	}
 	return &StreamWriter{
-		w:       w,
-		flusher: flusher,
+		w:  w,
+		rc: http.NewResponseController(w),
 	}
 }
 
@@ -51,11 +49,13 @@ func (sw *StreamWriter) Send(event SSEEvent) error {
 		sw.w.Header().Set("Connection", "keep-alive")
 		sw.w.Header().Set("X-Accel-Buffering", "no")
 		sw.w.WriteHeader(http.StatusOK)
-		sw.flusher.Flush()
+		if err := sw.rc.Flush(); err != nil {
+			return err
+		}
 		sw.started = true
 	}
 
-	return writeSSEEvent(sw.w, sw.flusher, event)
+	return writeSSEEvent(sw.w, sw.rc, event)
 }
 
 // SendJSON sends an SSE event with JSON-encoded data and an optional event type.


### PR DESCRIPTION
Two streaming bugs found by the live segovia demo (both invisible to httptest):

1. **Wrapped writers hid Flusher**: `httpmid.Logger`'s `statusWriter` doesn't implement `http.Flusher`, so SSE under any logged route 500'd "streaming not supported". Fix: `statusWriter.Unwrap()` + `http.ResponseController` in `SSEStream`/`StreamWriter`.
2. **Server WriteTimeout kills streams**: the deadline arms at request start; segovia's streams died at exactly **25.001s** — the first heartbeat after the timeout. Fix: per-frame write-deadline extension (4× heartbeat / 2m), the missing half of the plan's "heartbeat + write-deadline handling" work item.

Regression tests: sdk-level ping delivery; ssebridge suite now runs under a logger-wrapped chain. **Live-verified against segovia's production stack** (replace experiment): anon 401 → authed 200 → `: ping` received through the full middleware chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)