### PR TITLE
fix(init): authentication implies authorization — broken combo rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
+## Unreleased
+
+### Fixed
+- `init --features=authentication` (without authorization) scaffolded a
+  non-compiling project — generated bridges wire both engines
+  (authorizer parameters, relationship cleanup, auth schemas).
+  Authentication now implies authorization at init, and a hand-edited
+  manifest with the broken combination fails at load with guidance.
+- Repo-wide gofmt sweep; CI's build-and-unit job now gates formatting.
+
 ## v0.5.1 — 2026-06-12
 
 ### Fixed

--- a/workshop/codegen/initialize/options.go
+++ b/workshop/codegen/initialize/options.go
@@ -245,6 +245,14 @@ func ParseFeaturesFlag(value string) (FeatureSelection, error) {
 			return features, fmt.Errorf("unknown feature %q (valid: authentication, authorization, tenancy, event-outbox, job-queue, none, all)", name)
 		}
 	}
+	// Authentication implies authorization: generated bridges with auth
+	// enabled wire both engines (authorizer constructor params, delete
+	// cleanup, AuthSchema composites) — an authentication-only scaffold
+	// does not compile. Coupling here keeps init honest instead of
+	// emitting a broken project.
+	if features.Authentication && !features.Authorization {
+		features.Authorization = true
+	}
 	return features, nil
 }
 

--- a/workshop/codegen/initialize/options_test.go
+++ b/workshop/codegen/initialize/options_test.go
@@ -1,0 +1,23 @@
+package initialize
+
+import "testing"
+
+// Authentication implies authorization — an authentication-only scaffold
+// does not compile (generated bridges wire both engines).
+func TestParseFeaturesFlagCouplesAuthorization(t *testing.T) {
+	f, err := ParseFeaturesFlag("authentication")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.Authentication || !f.Authorization {
+		t.Errorf("authentication=%v authorization=%v, want both true", f.Authentication, f.Authorization)
+	}
+
+	f, err = ParseFeaturesFlag("tenancy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Authorization {
+		t.Error("tenancy alone must not enable authorization")
+	}
+}

--- a/workshop/codegen/manifest/manifest.go
+++ b/workshop/codegen/manifest/manifest.go
@@ -367,7 +367,20 @@ func Load(root string) (*Manifest, error) {
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", Filename, err)
 	}
+	if err := m.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", Filename, err)
+	}
 	return &m, nil
+}
+
+// validate rejects manifest combinations the generated output cannot
+// support, with guidance — better one clear error here than an opaque
+// compile failure far from its cause.
+func (m *Manifest) validate() error {
+	if m.Features.AuthenticationEnabled() && !m.Features.AuthorizationEnabled() {
+		return fmt.Errorf("features: authentication requires authorization — generated bridges wire both engines (authorizer parameters, relationship cleanup, auth schemas); add an authorization provider under features")
+	}
+	return nil
 }
 
 // Save writes the manifest to gopernicus.yml in the given project root.

--- a/workshop/codegen/manifest/manifest_test.go
+++ b/workshop/codegen/manifest/manifest_test.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -188,5 +190,35 @@ func TestNewWithProject_DriverDefault(t *testing.T) {
 	}
 	if mode != StoreModePgx {
 		t.Errorf("scaffolded store mode = %q, want %q", mode, StoreModePgx)
+	}
+}
+
+// An authentication-only manifest is rejected at load with guidance — the
+// generated output wires both engines and cannot compile without
+// authorization.
+func TestLoadRejectsAuthenticationWithoutAuthorization(t *testing.T) {
+	dir := t.TempDir()
+	yml := `version: "1"
+databases:
+    primary:
+        driver: postgres
+        url_env_var: X_DB_DATABASE_URL
+features:
+    authentication: gopernicus
+`
+	if err := os.WriteFile(filepath.Join(dir, Filename), []byte(yml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "authentication requires authorization") {
+		t.Fatalf("err = %v, want authentication-requires-authorization guidance", err)
+	}
+
+	yml += "    authorization: gopernicus\n"
+	if err := os.WriteFile(filepath.Join(dir, Filename), []byte(yml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("both features must load: %v", err)
 	}
 }


### PR DESCRIPTION
Filed in #35: \`init --features=authentication\` (without authorization) scaffolds a non-compiling project — generated bridges wire both engines, but the composition root and authschema emissions are authorization-gated.

Fix at two seams: `ParseFeaturesFlag` couples authentication → authorization; `manifest.Load` rejects the hand-edited combination with guidance ("authentication requires authorization — …") instead of an opaque compile error.

**Verified by replaying the original failure end to end**: init authentication-only → manifest carries both → migrate → reflect → generate → `go build ./...` clean. Unit tests pin the coupling and the load-time rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)