### PR TITLE
docs: cut the v0.5.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## Unreleased
+## v0.5.3 — 2026-06-12
 
 ### Added
 - **Recurring jobs (scheduler)**: new `job_schedules` feature entity


### PR DESCRIPTION
Unreleased → v0.5.3 (recurring-jobs scheduler). Tag follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)