### PR TITLE
feat(deploy): deploy profiles (do-app, cloud-run) + probe contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
+## Unreleased
+
+### Added
+- **Deploy profiles**: `gopernicus new deploy <target>` emits a runbook +
+  pipeline files under `workshop/deploy/<target>/` (workflows under
+  `.github/workflows/`). Targets: `do-app` (DigitalOcean App Platform —
+  tag-triggered workflow generalizing segovia's production pipeline:
+  tag-on-main guard, ghcr build with BUILD_REF/BUILD_DATE, migrations as
+  a release step via the pinned tool, `app_action` refresh — plus a
+  reference app spec) and `cloud-run` (Google Cloud Run — make targets
+  generalizing bluemark-redirector's flow: `cloud-bootstrap`/`cloud-build`/
+  `cloud-migrate`/`cloud-deploy`/`cloud-ship`/`cloud-url`/`cloud-logs`,
+  included from the root Makefile). Everything emitted is created-once
+  with a drift marker; profiles never modify existing files.
+- **Probe contract**: scaffolded servers expose `/readyz` (readiness —
+  pings the database, 503 on outage) alongside `/healthz` (liveness —
+  dependency-free, now reports the running `build` ref). Load balancers
+  route on readyz; restart checks stay on healthz.
+- Drift markers extended to non-Go files: `#` style for
+  yaml/makefile/shell (shebang-aware), `<!-- -->` for markdown; doctor
+  tracks markers under `workshop/deploy/` and `.github/workflows/`.
+- Docs: new `topics/deployment.md` (targets, probe contract, version
+  stamping, migrate-as-release-step policy); `cli/new.md` covers
+  `new deploy`.
+
+### Consumer actions
+- Optional — existing projects' bootstrap files are never overwritten:
+  - Run `go tool gopernicus new deploy do-app` and/or `cloud-run` to
+    emit pipelines for an existing app.
+  - To adopt the probe contract, copy the `/healthz` + `/readyz` block
+    from a fresh scaffold's `app/server/config/server.go` (segovia and
+    other pre-existing apps keep working without it; deploy runbooks
+    assume the endpoints exist).
+
 ## v0.5.3 — 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## Unreleased
+## v0.5.3 — 2026-06-12
 
 ### Added
 - **Recurring jobs (scheduler)**: new `job_schedules` feature entity

--- a/workshop/codegen/generators/app_tmpl.go
+++ b/workshop/codegen/generators/app_tmpl.go
@@ -340,6 +340,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gopernicus/gopernicus/bridge/transit/httpmid"
 	"github.com/gopernicus/gopernicus/telemetry"
@@ -665,9 +666,22 @@ func New(ctx context.Context, log *slog.Logger, cfg Config, infra Infrastructure
 	// Routes
 	// =========================================================================
 
-	// Health check
+	// Probe contract: /healthz is LIVENESS — dependency-free, answers as
+	// long as the process serves HTTP, so a database outage never makes
+	// the platform restart healthy processes. /readyz is READINESS —
+	// answers 200 only when downstream dependencies are reachable, so
+	// load balancers route traffic elsewhere during an outage.
 	webHandler.Handle("GET", "/healthz", func(w http.ResponseWriter, r *http.Request) {
-		web.RespondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		web.RespondJSON(w, http.StatusOK, map[string]string{"status": "ok", "build": cfg.Build})
+	})
+	webHandler.Handle("GET", "/readyz", func(w http.ResponseWriter, r *http.Request) {
+		probeCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		if err := infra.Pool.Ping(probeCtx); err != nil {
+			web.RespondJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "unready", "reason": "database unreachable"})
+			return
+		}
+		web.RespondJSON(w, http.StatusOK, map[string]string{"status": "ready"})
 	})
 
 	api := webHandler.Group("/api/v1")

--- a/workshop/codegen/generators/bootstrap_registry.go
+++ b/workshop/codegen/generators/bootstrap_registry.go
@@ -7,13 +7,21 @@ import (
 	"strings"
 )
 
-// bootstrapMarkerPrefix opens the marker line written as the first line of
-// every bootstrap file at creation time. The marker records which template
-// (by content hash) created the file, so doctor can detect when a project
-// carries a bootstrap from an older template vintage. The hash covers the
-// TEMPLATE, not the rendered file — user edits to bootstraps are expected
-// and never count as drift.
-const bootstrapMarkerPrefix = "// gopernicus:bootstrap "
+// The marker line is written as the first line of every bootstrap file at
+// creation time (second line when the file opens with a shebang). The
+// marker records which template (by content hash) created the file, so
+// doctor can detect when a project carries a bootstrap from an older
+// template vintage. The hash covers the TEMPLATE, not the rendered file —
+// user edits to bootstraps are expected and never count as drift.
+//
+// The marker body is identical across comment styles; only the comment
+// syntax varies by file type: `//` for Go/TypeScript, `#` for
+// yaml/makefile/shell-family files, `<!-- -->` for markdown.
+const (
+	bootstrapMarkerPrefix     = "// gopernicus:bootstrap "
+	bootstrapMarkerPrefixHash = "# gopernicus:bootstrap "
+	bootstrapMarkerPrefixMD   = "<!-- gopernicus:bootstrap "
+)
 
 // bootstrapTemplates is the registry of every bootstrap kind the generators
 // emit, mapping kind → the template constant that renders it. Kind names
@@ -37,6 +45,14 @@ var bootstrapTemplates = map[string]string{
 	"bridge-e2e/e2e_test.go":           bridgeE2EBootstrapTemplate,
 	"bridge-security/security_test.go": bridgeSecurityBootstrapTemplate,
 	"tsclient/client.ts":               tsClientBootstrapTemplate,
+
+	// Deploy profiles (gopernicus new deploy <target>) — non-Go files;
+	// markers use the comment style matching each file type.
+	"deploy/do-app/workflow.yml":          deployDoAppWorkflowTemplate,
+	"deploy/do-app/app-spec.yaml":         deployDoAppSpecTemplate,
+	"deploy/do-app/README.md":             deployDoAppReadmeTemplate,
+	"deploy/cloud-run/makefile.cloud-run": deployCloudRunMakefileTemplate,
+	"deploy/cloud-run/README.md":          deployCloudRunReadmeTemplate,
 }
 
 // BootstrapTemplateHash returns the content hash of the registered template
@@ -62,12 +78,21 @@ func BootstrapBasenames() map[string]bool {
 }
 
 // ParseBootstrapMarker parses a bootstrap marker line into its kind and
-// template hash. ok is false when the line is not a marker.
+// template hash, accepting any of the comment styles. ok is false when
+// the line is not a marker.
 func ParseBootstrapMarker(line string) (kind, hash string, ok bool) {
-	rest, found := strings.CutPrefix(strings.TrimSpace(line), bootstrapMarkerPrefix)
+	line = strings.TrimSpace(line)
+	var rest string
+	var found bool
+	for _, prefix := range []string{bootstrapMarkerPrefix, bootstrapMarkerPrefixHash, bootstrapMarkerPrefixMD} {
+		if rest, found = strings.CutPrefix(line, prefix); found {
+			break
+		}
+	}
 	if !found {
 		return "", "", false
 	}
+	rest = strings.TrimSuffix(strings.TrimSpace(rest), "-->")
 	for _, field := range strings.Fields(rest) {
 		if v, found := strings.CutPrefix(field, "kind="); found {
 			kind = v
@@ -89,6 +114,31 @@ func prependBootstrapMarker(kind string, rendered []byte) []byte {
 		panic(fmt.Sprintf("generators: bootstrap kind %q not in bootstrapTemplates — register it in bootstrap_registry.go", kind))
 	}
 	marker := fmt.Sprintf("%skind=%s template=%s\n", bootstrapMarkerPrefix, kind, hashTemplate(tmpl))
+	return append([]byte(marker), rendered...)
+}
+
+// prependBootstrapMarkerStyled is prependBootstrapMarker for non-Go files:
+// the comment style is chosen from the destination filename. Shell files
+// keep their shebang on line 1 — the marker goes on line 2.
+func prependBootstrapMarkerStyled(kind, filename string, rendered []byte) []byte {
+	tmpl, ok := bootstrapTemplates[kind]
+	if !ok {
+		panic(fmt.Sprintf("generators: bootstrap kind %q not in bootstrapTemplates — register it in bootstrap_registry.go", kind))
+	}
+
+	var marker string
+	switch {
+	case strings.HasSuffix(filename, ".md"):
+		marker = fmt.Sprintf("%skind=%s template=%s -->\n", bootstrapMarkerPrefixMD, kind, hashTemplate(tmpl))
+	case strings.HasSuffix(filename, ".go") || strings.HasSuffix(filename, ".ts"):
+		marker = fmt.Sprintf("%skind=%s template=%s\n", bootstrapMarkerPrefix, kind, hashTemplate(tmpl))
+	default: // yaml, makefile, shell, Caddyfile, systemd units, cron
+		marker = fmt.Sprintf("%skind=%s template=%s\n", bootstrapMarkerPrefixHash, kind, hashTemplate(tmpl))
+	}
+
+	if shebang, body, found := strings.Cut(string(rendered), "\n"); found && strings.HasPrefix(shebang, "#!") {
+		return []byte(shebang + "\n" + marker + body)
+	}
 	return append([]byte(marker), rendered...)
 }
 

--- a/workshop/codegen/generators/deploy.go
+++ b/workshop/codegen/generators/deploy.go
@@ -1,0 +1,91 @@
+package generators
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+// DeployTargets lists the deploy profiles `gopernicus new deploy` can emit,
+// in recommendation order.
+var DeployTargets = []string{"do-app", "cloud-run"}
+
+// deployProfiles maps each target to the files it emits. Workflow files
+// must live under .github/workflows/ to fire; everything else lives under
+// workshop/deploy/<target>/. All files are created-once bootstraps with
+// drift markers; profiles never modify existing files.
+var deployProfiles = map[string][]deployFile{
+	"do-app": {
+		{relPath: ".github/workflows/deploy-%s-do.yml", kind: "deploy/do-app/workflow.yml", altDelims: true},
+		{relPath: "workshop/deploy/do-app/app-spec.yaml", kind: "deploy/do-app/app-spec.yaml"},
+		{relPath: "workshop/deploy/do-app/README.md", kind: "deploy/do-app/README.md"},
+	},
+	"cloud-run": {
+		{relPath: "workshop/deploy/cloud-run/makefile.cloud-run", kind: "deploy/cloud-run/makefile.cloud-run", altDelims: true},
+		{relPath: "workshop/deploy/cloud-run/README.md", kind: "deploy/cloud-run/README.md"},
+	},
+}
+
+// deployFile is one emitted profile file. relPath may carry one %s, filled
+// with the project name. altDelims selects [[ ]] template delimiters for
+// payloads whose syntax collides with {{ }} (GitHub Actions, make).
+type deployFile struct {
+	relPath   string
+	kind      string
+	altDelims bool
+}
+
+// DeployData is the template data for deploy profile files.
+type DeployData struct {
+	ProjectName  string
+	AppNameUpper string
+}
+
+// GenerateDeployProfile emits one deploy target's files into the project.
+// Existing files are never touched — emitting is repeatable and additive.
+func GenerateDeployProfile(root, target string, data DeployData) error {
+	files, ok := deployProfiles[target]
+	if !ok {
+		return fmt.Errorf("unknown deploy target %q (valid: %v)", target, DeployTargets)
+	}
+
+	for _, f := range files {
+		rel := f.relPath
+		if contains := bytes.Contains([]byte(rel), []byte("%s")); contains {
+			rel = fmt.Sprintf(rel, data.ProjectName)
+		}
+		dst := filepath.Join(root, filepath.FromSlash(rel))
+
+		if _, err := os.Stat(dst); err == nil {
+			fmt.Printf("  • %s exists, skipping (bootstrap)\n", rel)
+			continue
+		}
+
+		tmplSrc := bootstrapTemplates[f.kind]
+		tmpl := template.New(f.kind)
+		if f.altDelims {
+			tmpl = tmpl.Delims("[[", "]]")
+		}
+		tmpl, err := tmpl.Parse(tmplSrc)
+		if err != nil {
+			return fmt.Errorf("parsing deploy template %s: %w", f.kind, err)
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, data); err != nil {
+			return fmt.Errorf("rendering %s: %w", rel, err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("creating directory for %s: %w", rel, err)
+		}
+		out := prependBootstrapMarkerStyled(f.kind, rel, buf.Bytes())
+		if err := os.WriteFile(dst, out, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", rel, err)
+		}
+		fmt.Printf("  ✓ %s\n", rel)
+	}
+	return nil
+}

--- a/workshop/codegen/generators/deploy_test.go
+++ b/workshop/codegen/generators/deploy_test.go
@@ -1,0 +1,143 @@
+package generators
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateDeployProfileDoApp(t *testing.T) {
+	root := t.TempDir()
+	data := DeployData{ProjectName: "myapp", AppNameUpper: "MYAPP"}
+
+	if err := GenerateDeployProfile(root, "do-app", data); err != nil {
+		t.Fatal(err)
+	}
+
+	wf := filepath.Join(root, ".github", "workflows", "deploy-myapp-do.yml")
+	body, err := os.ReadFile(wf)
+	if err != nil {
+		t.Fatalf("workflow not emitted: %v", err)
+	}
+	s := string(body)
+
+	// Marker first, # style, parseable, correct kind.
+	first := strings.SplitN(s, "\n", 2)[0]
+	kind, hash, ok := ParseBootstrapMarker(first)
+	if !ok || kind != "deploy/do-app/workflow.yml" || hash == "" {
+		t.Fatalf("workflow marker = %q (kind=%q ok=%v)", first, kind, ok)
+	}
+
+	// Template data substituted; GitHub Actions syntax left intact.
+	for _, want := range []string{
+		`tags:`, `"prod.myapp.*"`,
+		"${{ github.sha }}",
+		"dockerfile.myapp",
+		"MYAPP_DB_DATABASE_URL: ${{ secrets.PROD_MYAPP_PG_URL }}",
+		"go tool gopernicus db migrate",
+		"app_name: prod-myapp",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("workflow missing %q", want)
+		}
+	}
+	if strings.Contains(s, "[[") || strings.Contains(s, "{{.") {
+		t.Error("unrendered template syntax left in workflow")
+	}
+
+	// README carries an HTML-comment marker (a # line would be a heading).
+	readme, err := os.ReadFile(filepath.Join(root, "workshop", "deploy", "do-app", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mdFirst := strings.SplitN(string(readme), "\n", 2)[0]
+	if kind, _, ok := ParseBootstrapMarker(mdFirst); !ok || kind != "deploy/do-app/README.md" {
+		t.Errorf("README marker = %q", mdFirst)
+	}
+	if !strings.HasPrefix(mdFirst, "<!-- ") || !strings.HasSuffix(mdFirst, " -->") {
+		t.Errorf("README marker must be an HTML comment, got %q", mdFirst)
+	}
+
+	// Created-once: re-emitting must not touch existing files.
+	if err := os.WriteFile(wf, []byte("user-owned"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := GenerateDeployProfile(root, "do-app", data); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(wf)
+	if string(after) != "user-owned" {
+		t.Error("re-emission overwrote a user-owned bootstrap")
+	}
+}
+
+func TestGenerateDeployProfileCloudRun(t *testing.T) {
+	root := t.TempDir()
+	data := DeployData{ProjectName: "myapp", AppNameUpper: "MYAPP"}
+
+	if err := GenerateDeployProfile(root, "cloud-run", data); err != nil {
+		t.Fatal(err)
+	}
+
+	mk, err := os.ReadFile(filepath.Join(root, "workshop", "deploy", "cloud-run", "makefile.cloud-run"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(mk)
+	if kind, _, ok := ParseBootstrapMarker(strings.SplitN(s, "\n", 2)[0]); !ok || kind != "deploy/cloud-run/makefile.cloud-run" {
+		t.Fatalf("makefile marker bad: %q", strings.SplitN(s, "\n", 2)[0])
+	}
+	for _, want := range []string{
+		"cloud-bootstrap:", "cloud-build:", "cloud-migrate:", "cloud-deploy:", "cloud-ship:", "cloud-url:",
+		"dockerfile.myapp",
+		"MYAPP_DB_DATABASE_URL",
+		"--set-env-vars=MYAPP_PORT=8080",
+		"$(CLOUD_RUN_IMAGE)", // make syntax intact
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("makefile missing %q", want)
+		}
+	}
+	if strings.Contains(s, "[[") {
+		t.Error("unrendered template syntax left in makefile")
+	}
+}
+
+func TestGenerateDeployProfileUnknownTarget(t *testing.T) {
+	if err := GenerateDeployProfile(t.TempDir(), "k8s", DeployData{}); err == nil {
+		t.Fatal("unknown target must error")
+	}
+}
+
+// The three marker comment styles all round-trip through the parser, and
+// a shebang keeps line 1 of shell files.
+func TestStyledMarkers(t *testing.T) {
+	cases := []struct {
+		filename string
+		prefix   string
+	}{
+		{"workflow.yml", "# gopernicus:bootstrap "},
+		{"README.md", "<!-- gopernicus:bootstrap "},
+		{"client.ts", "// gopernicus:bootstrap "},
+	}
+	for _, tc := range cases {
+		out := prependBootstrapMarkerStyled("deploy/do-app/workflow.yml", tc.filename, []byte("body\n"))
+		first := strings.SplitN(string(out), "\n", 2)[0]
+		if !strings.HasPrefix(first, tc.prefix) {
+			t.Errorf("%s: marker = %q, want prefix %q", tc.filename, first, tc.prefix)
+		}
+		if kind, hash, ok := ParseBootstrapMarker(first); !ok || kind == "" || hash == "" {
+			t.Errorf("%s: marker does not round-trip: %q", tc.filename, first)
+		}
+	}
+
+	sh := prependBootstrapMarkerStyled("deploy/do-app/workflow.yml", "deploy.sh", []byte("#!/usr/bin/env bash\nset -e\n"))
+	lines := strings.SplitN(string(sh), "\n", 3)
+	if lines[0] != "#!/usr/bin/env bash" {
+		t.Errorf("shebang displaced: %q", lines[0])
+	}
+	if _, _, ok := ParseBootstrapMarker(lines[1]); !ok {
+		t.Errorf("marker not on line 2 of shell file: %q", lines[1])
+	}
+}

--- a/workshop/codegen/generators/deploy_tmpl.go
+++ b/workshop/codegen/generators/deploy_tmpl.go
@@ -1,0 +1,286 @@
+package generators
+
+// Deploy profile templates. These generalize real production pipelines:
+// do-app transcribes segovia's tag-triggered GitHub workflow (ghcr build →
+// migrate as a release step → DigitalOcean app_action), cloud-run
+// transcribes bluemark-redirector's make-driven gcloud flow. Workflow and
+// makefile templates use [[ ]] delimiters because their payloads contain
+// `${{ }}` (GitHub Actions) and `$( )` (make) syntax that collides with
+// the default {{ }}.
+
+// deployDoAppWorkflowTemplate produces .github/workflows/deploy-<app>-do.yml.
+const deployDoAppWorkflowTemplate = `name: Build and Deploy [[.ProjectName]] to DigitalOcean
+on:
+  push:
+    tags:
+      - "prod.[[.ProjectName]].*"
+
+jobs:
+  build-migrate-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Deploys only ship from main: a tag on any other branch fails loud.
+      - name: Verify tag is on main
+        run: |
+          git branch -r --contains "${{ github.sha }}" | grep -qE 'origin/main$' || \
+            { echo "::error::Tag is not on the main branch"; exit 1; }
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: ./workshop/docker/dockerfile.[[.ProjectName]]
+          build-args: |
+            BUILD_REF=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.pushed_at }}
+          tags: |
+            ghcr.io/${{ github.repository }}-api:latest
+            ghcr.io/${{ github.repository }}-api:${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Migrations run as a RELEASE STEP, never at boot: a bad migration
+      # fails the deploy here, before any new instance starts.
+      - name: Run database migrations
+        env:
+          [[.AppNameUpper]]_DB_DATABASE_URL: ${{ secrets.PROD_[[.AppNameUpper]]_PG_URL }}
+        run: go tool gopernicus db migrate
+
+      - name: Deploy the API
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITAL_OCEAN_ACCESS_TOKEN }}
+          app_name: prod-[[.ProjectName]]
+`
+
+// deployDoAppSpecTemplate produces workshop/deploy/do-app/app-spec.yaml —
+// the reference DigitalOcean app spec the workflow deploys into.
+const deployDoAppSpecTemplate = `# Reference DigitalOcean App Platform spec for {{.ProjectName}}.
+# Create the app once (doctl apps create --spec app-spec.yaml, or via the
+# control panel) — the deploy workflow then refreshes it by app_name.
+# Replace <github-org>/<repo> with your repository.
+name: prod-{{.ProjectName}}
+services:
+  - name: api
+    image:
+      registry_type: GHCR
+      registry: <github-org>
+      repository: <repo>-api
+      tag: latest
+    http_port: 3000
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    health_check:
+      http_path: /healthz
+    # Environment: set {{.AppNameUpper}}_* vars here or in the control
+    # panel; mark secrets (database URL, JWT secret) as type SECRET.
+    # envs:
+    #   - key: {{.AppNameUpper}}_DB_DATABASE_URL
+    #     type: SECRET
+    #     value: postgres://...
+`
+
+// deployDoAppReadmeTemplate produces workshop/deploy/do-app/README.md.
+const deployDoAppReadmeTemplate = `# Deploying {{.ProjectName}} to DigitalOcean App Platform
+
+Tag-triggered pipeline: pushing a ` + "`prod.{{.ProjectName}}.*`" + ` tag on main
+builds the image, runs migrations as a release step, and refreshes the DO
+app. The workflow lives at
+` + "`.github/workflows/deploy-{{.ProjectName}}-do.yml`" + `.
+
+## One-time setup
+
+1. **Create the app** from the reference spec (edit placeholders first):
+
+       doctl apps create --spec workshop/deploy/do-app/app-spec.yaml
+
+   Or create it in the control panel; the workflow targets it by
+   ` + "`app_name: prod-{{.ProjectName}}`" + `.
+
+2. **Repository secrets** (GitHub → Settings → Secrets and variables):
+   - ` + "`DIGITAL_OCEAN_ACCESS_TOKEN`" + ` — DO API token with app deploy scope.
+   - ` + "`PROD_{{.AppNameUpper}}_PG_URL`" + ` — production database URL the
+     migrate step uses.
+
+3. **App environment**: set ` + "`{{.AppNameUpper}}_*`" + ` env vars on the DO app
+   (database URL, JWT secret, allowed frontends, …) — the container reads
+   configuration from the environment only.
+
+## Deploying
+
+    git tag prod.{{.ProjectName}}.1 && git push origin prod.{{.ProjectName}}.1
+
+The workflow refuses tags that are not on main. Each deploy: ghcr image
+(stamped with ` + "`BUILD_REF`" + ` — visible in startup logs and ` + "`/healthz`" + `) →
+migrations (` + "`go tool gopernicus db migrate`" + `, **never at boot** — a bad
+migration fails the deploy before any new instance starts) → app refresh.
+
+## Probes
+
+- ` + "`/healthz`" + ` — liveness, dependency-free (configured in the app spec).
+- ` + "`/readyz`" + ` — readiness, pings the database; point the platform's
+  readiness/load-balancer check here if you separate the two.
+
+## Rollback
+
+Deploys are immutable images tagged by commit SHA. Roll back by deploying
+a previous SHA from the DO control panel (Deployments → Rollback), or by
+tagging the previous good commit (` + "`prod.{{.ProjectName}}.N+1`" + ` on the old
+SHA). Migrations are forward-only — write down-safe migrations or restore
+from backup for schema rollback.
+`
+
+// deployCloudRunMakefileTemplate produces
+// workshop/deploy/cloud-run/makefile.cloud-run. Include it from the root
+// Makefile; it reuses the root's BINARY/VERSION vars (with fallbacks).
+const deployCloudRunMakefileTemplate = `# Cloud Run deploy targets for [[.ProjectName]].
+# Include from the root Makefile:
+#   include workshop/deploy/cloud-run/makefile.cloud-run
+# Override any var via env or CLI: make cloud-deploy GCP_REGION=us-east1
+
+BINARY     ?= [[.ProjectName]]
+VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GOPERNICUS ?= go tool gopernicus
+
+GCP_PROJECT_ID    ?= <your-gcp-project>
+GCP_REGION        ?= us-central1
+ARTIFACT_REPO     ?= [[.ProjectName]]
+CLOUD_RUN_SERVICE ?= $(BINARY)
+# Strip defends against trailing whitespace / accidental inline comments on
+# the var lines above — Make would otherwise include them in the value.
+GCP_PROJECT_ID    := $(strip $(GCP_PROJECT_ID))
+GCP_REGION        := $(strip $(GCP_REGION))
+ARTIFACT_REPO     := $(strip $(ARTIFACT_REPO))
+CLOUD_RUN_SERVICE := $(strip $(CLOUD_RUN_SERVICE))
+RUNTIME_SA             := $(CLOUD_RUN_SERVICE)@$(GCP_PROJECT_ID).iam.gserviceaccount.com
+CLOUD_RUN_IMAGE        := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(ARTIFACT_REPO)/$(CLOUD_RUN_SERVICE):$(VERSION)
+CLOUD_RUN_IMAGE_LATEST := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(ARTIFACT_REPO)/$(CLOUD_RUN_SERVICE):latest
+
+.PHONY: cloud-bootstrap
+cloud-bootstrap: ## One-time GCP setup: enable APIs, create Artifact Registry repo + runtime SA
+	gcloud services enable \
+		run.googleapis.com \
+		artifactregistry.googleapis.com \
+		iamcredentials.googleapis.com \
+		--project=$(GCP_PROJECT_ID)
+	-gcloud artifacts repositories create $(ARTIFACT_REPO) \
+		--repository-format=docker \
+		--location=$(GCP_REGION) \
+		--project=$(GCP_PROJECT_ID)
+	-gcloud iam service-accounts create $(CLOUD_RUN_SERVICE) \
+		--display-name="[[.ProjectName]] runtime" \
+		--project=$(GCP_PROJECT_ID)
+	gcloud auth configure-docker $(GCP_REGION)-docker.pkg.dev --quiet
+
+.PHONY: cloud-build
+cloud-build: ## Build linux/amd64 image and push to Artifact Registry
+	docker buildx build \
+		--platform=linux/amd64 \
+		-f workshop/docker/dockerfile.[[.ProjectName]] \
+		-t $(CLOUD_RUN_IMAGE) \
+		-t $(CLOUD_RUN_IMAGE_LATEST) \
+		--build-arg BUILD_REF=$(VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		--push \
+		.
+
+.PHONY: cloud-migrate
+cloud-migrate: ## Run migrations against the production database (release step, never at boot)
+	@test -n "$([[.AppNameUpper]]_DB_DATABASE_URL)" || \
+		{ echo "set [[.AppNameUpper]]_DB_DATABASE_URL to the production database URL"; exit 2; }
+	$(GOPERNICUS) db migrate
+
+# Add the rest of your runtime env with more --set-env-vars/--set-secrets
+# flags on cloud-deploy (the database URL belongs in Secret Manager via
+# --set-secrets).
+.PHONY: cloud-deploy
+cloud-deploy: ## Deploy the pushed image to Cloud Run
+	gcloud run deploy $(CLOUD_RUN_SERVICE) \
+		--image=$(CLOUD_RUN_IMAGE) \
+		--region=$(GCP_REGION) \
+		--project=$(GCP_PROJECT_ID) \
+		--platform=managed \
+		--service-account=$(RUNTIME_SA) \
+		--allow-unauthenticated \
+		--set-env-vars=[[.AppNameUpper]]_PORT=8080
+
+.PHONY: cloud-ship
+cloud-ship: cloud-build cloud-migrate cloud-deploy ## Build, push, migrate, and deploy in one shot
+
+.PHONY: cloud-url
+cloud-url: ## Print the deployed Cloud Run service URL
+	@gcloud run services describe $(CLOUD_RUN_SERVICE) \
+		--region=$(GCP_REGION) --project=$(GCP_PROJECT_ID) \
+		--format='value(status.url)'
+
+.PHONY: cloud-logs
+cloud-logs: ## Tail Cloud Run service logs
+	gcloud beta run services logs tail $(CLOUD_RUN_SERVICE) \
+		--region=$(GCP_REGION) --project=$(GCP_PROJECT_ID)
+`
+
+// deployCloudRunReadmeTemplate produces workshop/deploy/cloud-run/README.md.
+const deployCloudRunReadmeTemplate = `# Deploying {{.ProjectName}} to Google Cloud Run
+
+Make-driven pipeline. Wire it up by adding one line to the root Makefile:
+
+    include workshop/deploy/cloud-run/makefile.cloud-run
+
+## One-time setup
+
+1. Edit ` + "`GCP_PROJECT_ID`" + ` (and region/repo if needed) in
+   ` + "`makefile.cloud-run`" + `, or pass them per-invocation.
+2. Bootstrap GCP (enables APIs, creates the Artifact Registry repo and
+   runtime service account, configures docker auth):
+
+       make cloud-bootstrap
+
+3. Grant the runtime service account access to your database (e.g.
+   ` + "`roles/cloudsql.client`" + ` plus a Cloud SQL connection, or network access
+   to wherever Postgres lives) and put the database URL in Secret Manager.
+
+## Deploying
+
+    {{.AppNameUpper}}_DB_DATABASE_URL=<prod-url> make cloud-ship
+
+` + "`cloud-ship`" + ` = ` + "`cloud-build`" + ` (linux/amd64 image stamped with
+` + "`BUILD_REF`" + ` — visible in startup logs and ` + "`/healthz`" + `) →
+` + "`cloud-migrate`" + ` (**release step, never at boot** — a bad migration stops
+the deploy before any new revision starts) → ` + "`cloud-deploy`" + `.
+
+The deploy sets ` + "`{{.AppNameUpper}}_PORT=8080`" + ` to match Cloud Run's default
+container port. Add the rest of your runtime configuration with
+` + "`--set-env-vars`" + `/` + "`--set-secrets`" + ` flags on ` + "`cloud-deploy`" + `.
+
+## Probes
+
+- ` + "`/healthz`" + ` — liveness, dependency-free.
+- ` + "`/readyz`" + ` — readiness, pings the database. Configure it as the Cloud
+  Run startup probe (service YAML ` + "`startupProbe.httpGet.path: /readyz`" + `)
+  so revisions only receive traffic once the database is reachable.
+
+## Rollback
+
+Cloud Run keeps every revision:
+
+    gcloud run services update-traffic $(CLOUD_RUN_SERVICE) --to-revisions=<previous-revision>=100
+
+Migrations are forward-only — write down-safe migrations or restore from
+backup for schema rollback.
+`

--- a/workshop/documentation/docs/cli/new.md
+++ b/workshop/documentation/docs/cli/new.md
@@ -1,14 +1,15 @@
 # gopernicus new
 
-Scaffold new repositories, use cases, and infrastructure adapters from templates or reflected database schemas.
+Scaffold new repositories, use cases, infrastructure adapters, and deploy profiles from templates or reflected database schemas.
 
 ## Overview
 
-`gopernicus new` has three subcommands:
+`gopernicus new` has four subcommands:
 
 - `gopernicus new repo` -- scaffold a repository from reflected schema.
 - `gopernicus new case` -- scaffold a use case with core logic and HTTP bridge.
 - `gopernicus new adapter` -- scaffold a custom infrastructure adapter implementing a framework interface.
+- `gopernicus new deploy` -- emit a deploy profile (runbook + pipeline files) for a hosting target.
 
 ---
 
@@ -275,3 +276,30 @@ go test ./infrastructure/cache/redis/...
 - [boot](boot.md) -- batch-scaffold all repos for a domain
 - [db](db.md) -- reflect schema before scaffolding repos
 - [init](init.md) -- initial project setup
+
+---
+
+## gopernicus new deploy
+
+Emit a deploy profile for one hosting target: a runbook plus the pipeline
+files that ship the app there.
+
+```bash
+gopernicus new deploy do-app      # DigitalOcean App Platform
+gopernicus new deploy cloud-run   # Google Cloud Run
+```
+
+| Target | Style | Files |
+|---|---|---|
+| `do-app` | CI-driven | `.github/workflows/deploy-<app>-do.yml` (tag-triggered: ghcr build → migrate as release step → DO app refresh), `workshop/deploy/do-app/app-spec.yaml`, README runbook |
+| `cloud-run` | make-driven | `workshop/deploy/cloud-run/makefile.cloud-run` (`cloud-bootstrap` / `cloud-build` / `cloud-migrate` / `cloud-deploy` / `cloud-ship` / `cloud-url` / `cloud-logs`; include it from the root Makefile), README runbook |
+
+Everything emitted is a **created-once bootstrap with a drift marker** —
+you own the files after emission; re-running skips existing files.
+Profiles never modify existing files: they reference the dockerfile init
+emitted (`workshop/docker/dockerfile.<app>`) and document any required
+tweaks in their README. Emitting a second target adds a sibling directory
+under `workshop/deploy/`.
+
+See the [deployment topic](../gopernicus/topics/deployment.md) for the
+probe contract and the production migration policy the profiles embody.

--- a/workshop/documentation/docs/gopernicus/topics/deployment.md
+++ b/workshop/documentation/docs/gopernicus/topics/deployment.md
@@ -1,0 +1,76 @@
+---
+title: Deployment
+---
+
+# Deploying gopernicus apps
+
+`gopernicus new deploy <target>` emits a deploy profile: a runbook under
+`workshop/deploy/<target>/` plus the pipeline files for one hosting
+target (CI workflows land in `.github/workflows/` so they fire).
+Profiles generalize real production pipelines; after emission the files
+are yours — everything is created-once with a drift marker, and
+re-running never overwrites.
+
+| Target | What it is |
+|---|---|
+| `do-app` | DigitalOcean App Platform: tag-triggered GitHub workflow — ghcr image build, migrations as a release step, app refresh — plus a reference app spec |
+| `cloud-run` | Google Cloud Run: make targets (`cloud-bootstrap`, `cloud-build`, `cloud-migrate`, `cloud-deploy`, `cloud-ship`) included from the root Makefile |
+
+Each target's README is the runbook: one-time setup, deploy procedure,
+rollback notes.
+
+## The probe contract
+
+Every scaffolded server exposes two endpoints with strictly separated
+meanings:
+
+- **`/healthz` — liveness.** Dependency-free: answers 200 as long as the
+  process serves HTTP. Point platform *restart* checks here; a database
+  outage must never make the platform kill healthy processes.
+- **`/readyz` — readiness.** Answers 200 only when downstream
+  dependencies are reachable (pings the database with a 2s timeout; 503
+  otherwise). Point *traffic-routing* checks here so load balancers
+  drain an instance during an outage instead of restarting it.
+
+## Version stamping
+
+The scaffolded dockerfile passes `BUILD_REF` into the binary
+(`-X main.build`); deploy profiles set it to the commit SHA (do-app) or
+`git describe` (cloud-run). The running build is visible in the startup
+log line and in `/healthz`:
+
+```json
+{"status": "ok", "build": "3f2c1a9..."}
+```
+
+That makes "which commit is actually serving?" a curl, not an archaeology
+session.
+
+## Production migration policy: release step, never at boot
+
+Migrations run as an explicit deploy step (`go tool gopernicus db
+migrate` with the production database URL), **before** the new version
+starts:
+
+- A bad migration fails the *deploy*, not the running fleet — old
+  instances keep serving on the old schema.
+- Instances never race each other to migrate at startup.
+- Boot stays fast and dependency-light, which the probe contract relies
+  on.
+
+Both shipped profiles embody this: the do-app workflow migrates between
+image push and app refresh; cloud-run's `cloud-ship` runs
+`cloud-migrate` between build and deploy.
+
+Migrations are forward-only. For schema rollback, write down-safe
+migrations or restore from backup; for code rollback, redeploy a
+previous image (both runbooks cover the mechanics).
+
+## Drift markers in non-Go files
+
+Profile files carry the same `gopernicus:bootstrap` marker as Go
+bootstraps, in the comment style their format allows: `#` for
+yaml/makefiles/shell (after the shebang, when present), `<!-- -->` for
+markdown. `gopernicus doctor` tracks them under `workshop/deploy/` and
+`.github/workflows/` and warns when a file was created from an older
+template — a hint to diff against a fresh emission, never an error.

--- a/workshop/gopernicus/commands/doctor.go
+++ b/workshop/gopernicus/commands/doctor.go
@@ -312,23 +312,34 @@ func checkBootstrapDrift(root string) check {
 			}
 			return nil
 		}
-		if !basenames[d.Name()] || !strings.HasSuffix(d.Name(), ".go") {
-			return nil
-		}
 		rel, _ := filepath.Rel(root, path)
-		if !strings.HasPrefix(rel, "core"+string(filepath.Separator)) &&
-			!strings.HasPrefix(rel, "bridge"+string(filepath.Separator)) &&
-			!strings.HasPrefix(rel, filepath.Join("workshop", "testing")+string(filepath.Separator)) {
-			return nil
+
+		// Deploy profile files (workshop/deploy/, .github/workflows/) are
+		// non-Go bootstraps with app-specific names — any file there that
+		// carries a marker is tracked; unmarked files are the user's own.
+		deployFile := strings.HasPrefix(rel, filepath.Join("workshop", "deploy")+string(filepath.Separator)) ||
+			strings.HasPrefix(rel, filepath.Join(".github", "workflows")+string(filepath.Separator))
+
+		if !deployFile {
+			if !basenames[d.Name()] || !strings.HasSuffix(d.Name(), ".go") {
+				return nil
+			}
+			if !strings.HasPrefix(rel, "core"+string(filepath.Separator)) &&
+				!strings.HasPrefix(rel, "bridge"+string(filepath.Separator)) &&
+				!strings.HasPrefix(rel, filepath.Join("workshop", "testing")+string(filepath.Separator)) {
+				return nil
+			}
 		}
 
-		firstLine, rerr := readFirstLine(path)
+		firstLine, rerr := readMarkerLine(path)
 		if rerr != nil {
 			return nil
 		}
 		kind, hash, ok := generators.ParseBootstrapMarker(firstLine)
 		if !ok {
-			unmarked++
+			if !deployFile {
+				unmarked++
+			}
 			return nil
 		}
 		current, known := generators.BootstrapTemplateHash(kind)
@@ -365,8 +376,10 @@ func checkBootstrapDrift(root string) check {
 	return check{name: name, passed: true, detail: detail}
 }
 
-// readFirstLine returns the first line of a file without reading the rest.
-func readFirstLine(path string) (string, error) {
+// readMarkerLine returns the line a bootstrap marker would occupy: the
+// first line, or the second when the file opens with a shebang (shell
+// bootstraps keep `#!` on line 1).
+func readMarkerLine(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -374,7 +387,11 @@ func readFirstLine(path string) (string, error) {
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	if scanner.Scan() {
-		return scanner.Text(), nil
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#!") && scanner.Scan() {
+			return scanner.Text(), nil
+		}
+		return line, nil
 	}
 	return "", scanner.Err()
 }

--- a/workshop/gopernicus/commands/new.go
+++ b/workshop/gopernicus/commands/new.go
@@ -58,6 +58,29 @@ Examples:
 			Usage: "gopernicus new case <name>",
 			Run:   runNewCase,
 		},
+		{
+			Name:  "deploy",
+			Short: "Emit a deploy profile for a hosting target",
+			Long: `Emit a deploy profile: a runbook plus pipeline files for one target.
+
+Targets:
+  do-app     DigitalOcean App Platform — tag-triggered GitHub workflow
+             (ghcr build, migrate as release step, app refresh) + reference
+             app spec
+  cloud-run  Google Cloud Run — make targets (include from the root
+             Makefile): bootstrap, build, migrate, deploy, url, logs
+
+Files land in workshop/deploy/<target>/ (workflows in .github/workflows/).
+Everything is created-once with a drift marker — you own the files after
+emission; re-running never overwrites them. Emitting a second target adds
+a sibling directory.
+
+Examples:
+  gopernicus new deploy do-app
+  gopernicus new deploy cloud-run`,
+			Usage: "gopernicus new deploy <target>",
+			Run:   runNewDeploy,
+		},
 	}
 	newCmd.Run = runNew
 	cli.RegisterCommand(newCmd)

--- a/workshop/gopernicus/commands/new_deploy.go
+++ b/workshop/gopernicus/commands/new_deploy.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/gopernicus/gopernicus/workshop/codegen/generators"
+	"github.com/gopernicus/gopernicus/workshop/codegen/manifest"
+)
+
+// runNewDeploy emits a deploy profile: workshop/deploy/<target>/ runbook +
+// target files, plus a .github/workflows/ workflow for CI-driven targets.
+// Everything is a created-once bootstrap with a drift marker; profiles
+// never modify existing files.
+func runNewDeploy(_ context.Context, args []string) error {
+	target := firstPositional(args)
+	if target == "" {
+		return fmt.Errorf("deploy target required (valid: %s)\n\nUsage: gopernicus new deploy <target>",
+			strings.Join(generators.DeployTargets, ", "))
+	}
+
+	root, m, err := loadProject()
+	if err != nil {
+		return err
+	}
+
+	projectName := filepath.Base(root)
+	data := generators.DeployData{
+		ProjectName:  projectName,
+		AppNameUpper: appNameUpperFromManifest(m, projectName),
+	}
+
+	fmt.Printf("Emitting %s deploy profile for %s\n", target, projectName)
+	if err := generators.GenerateDeployProfile(root, target, data); err != nil {
+		return err
+	}
+
+	if !fileExists(filepath.Join(root, "workshop", "docker", "dockerfile."+projectName)) {
+		fmt.Printf("  ! workshop/docker/dockerfile.%s not found — the profile builds that image; check the dockerfile name\n", projectName)
+	}
+	fmt.Printf("\nNext: read workshop/deploy/%s/README.md for one-time setup and the deploy procedure.\n", target)
+	return nil
+}
+
+// appNameUpperFromManifest derives the project's env-var prefix. The
+// primary database's url_env_var encodes it (<APP>_DB_DATABASE_URL on
+// scaffolded projects); fall back to the project directory name.
+func appNameUpperFromManifest(m *manifest.Manifest, projectName string) string {
+	if db, ok := m.Databases["primary"]; ok && db != nil {
+		if prefix, found := strings.CutSuffix(db.URLEnvVar, "_DB_DATABASE_URL"); found && prefix != "" {
+			return prefix
+		}
+	}
+	return generators.AppNameFromProject(projectName)
+}


### PR DESCRIPTION
## Summary

Item B1 of the v0.5.x ops plan: `gopernicus new deploy <target>` plus the shared prerequisites every target needs.

- **`do-app`** — transcribes segovia's real production pipeline into a generated, tag-triggered workflow: tag-on-main guard → ghcr build (BUILD_REF/BUILD_DATE) → **migrations as a release step** (`go tool gopernicus db migrate`, standardized from segovia's bespoke script) → DigitalOcean `app_action` refresh. Plus a reference app spec and a runbook README.
- **`cloud-run`** — transcribes bluemark-redirector's make-driven flow: `cloud-bootstrap`/`cloud-build`/`cloud-deploy`/`cloud-ship`/`cloud-url`/`cloud-logs`, dropping the Firestore-specific bits and adding `cloud-migrate` for pg-backed apps. Included from the root Makefile (`include workshop/deploy/cloud-run/makefile.cloud-run`); root Makefile gains nothing.
- **Probe contract** (shared prereq): scaffolded servers expose `/readyz` (readiness — db ping, 503 on outage) alongside `/healthz` (liveness — dependency-free, now reports the `build` ref BUILD_REF stamps in).
- **Drift markers for non-Go files**: `#` style for yaml/makefile/shell (shebang-aware), `<!-- -->` for markdown; doctor tracks `workshop/deploy/` and `.github/workflows/`.
- Docs: `topics/deployment.md` + `cli/new.md`; CHANGELOG Unreleased (consumer actions are all optional emissions).

## Acceptance (per plan)

- Generated do-app workflow **diffs near-zero against segovia's hand-written workflow** — only names, comments, and the two intended standardizations (pinned-tool migrate, app_name shape).
- Generated cloud-run makefile **diffs near-zero against bluemark-redirector's targets** — Firestore bits dropped, `cloud-migrate` added; parses under `make -n` via the documented include, and the migrate guard fails loud without the prod URL.
- Probe contract verified live on a fresh scaffold: with the database container paused, `/readyz` → 503 `unready` while `/healthz` stays 200 with `"build":"test-ref-abc123"` — outage drains traffic without triggering restarts.
- Emission is idempotent (re-run skips, user-owned files untouched) and doctor tracks all five emitted markers on a synthetic consumer.

`compose-prod` (B2) follows in its own PR; v0.5.4 tags after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)