### PR TITLE
feat(deploy): compose-prod profile — the single-host compose stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ assume is documented in
 
 Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
-## v0.5.3 — 2026-06-12
+## v0.5.4 — 2026-06-15
 
 ### Added
 - **Deploy profiles**: `gopernicus new deploy <target>` emits a runbook +
@@ -40,8 +40,8 @@ Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
 
 ### Consumer actions
 - Optional — existing projects' bootstrap files are never overwritten:
-  - Run `go tool gopernicus new deploy do-app` and/or `cloud-run` to
-    emit pipelines for an existing app.
+  - Run `go tool gopernicus new deploy do-app`, `cloud-run`, and/or
+    `compose-prod` to emit pipelines for an existing app.
   - To adopt the probe contract, copy the `/healthz` + `/readyz` block
     from a fresh scaffold's `app/server/config/server.go` (segovia and
     other pre-existing apps keep working without it; deploy runbooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ Releases are tag-only: `git tag -a vX.Y.Z && git push origin vX.Y.Z`.
   reference app spec) and `cloud-run` (Google Cloud Run — make targets
   generalizing bluemark-redirector's flow: `cloud-bootstrap`/`cloud-build`/
   `cloud-migrate`/`cloud-deploy`/`cloud-ship`/`cloud-url`/`cloud-logs`,
-  included from the root Makefile). Everything emitted is created-once
-  with a drift marker; profiles never modify existing files.
+  included from the root Makefile) and `compose-prod` (single host, "the
+  $10 VPS" — compose stack with app + postgres + redis + caddy automatic
+  TLS, `deploy.sh` build→migrate→roll→readiness-wait, systemd unit, pg
+  backup script with rotation; migrations run in a one-off golang
+  container so the host needs no Go toolchain). Everything emitted is
+  created-once with a drift marker; profiles never modify existing
+  files.
 - **Probe contract**: scaffolded servers expose `/readyz` (readiness —
   pings the database, 503 on outage) alongside `/healthz` (liveness —
   dependency-free, now reports the running `build` ref). Load balancers

--- a/workshop/codegen/generators/bootstrap_registry.go
+++ b/workshop/codegen/generators/bootstrap_registry.go
@@ -48,11 +48,17 @@ var bootstrapTemplates = map[string]string{
 
 	// Deploy profiles (gopernicus new deploy <target>) — non-Go files;
 	// markers use the comment style matching each file type.
-	"deploy/do-app/workflow.yml":          deployDoAppWorkflowTemplate,
-	"deploy/do-app/app-spec.yaml":         deployDoAppSpecTemplate,
-	"deploy/do-app/README.md":             deployDoAppReadmeTemplate,
-	"deploy/cloud-run/makefile.cloud-run": deployCloudRunMakefileTemplate,
-	"deploy/cloud-run/README.md":          deployCloudRunReadmeTemplate,
+	"deploy/do-app/workflow.yml":           deployDoAppWorkflowTemplate,
+	"deploy/do-app/app-spec.yaml":          deployDoAppSpecTemplate,
+	"deploy/do-app/README.md":              deployDoAppReadmeTemplate,
+	"deploy/cloud-run/makefile.cloud-run":  deployCloudRunMakefileTemplate,
+	"deploy/cloud-run/README.md":           deployCloudRunReadmeTemplate,
+	"deploy/compose-prod/compose.prod.yml": deployComposeProdComposeTemplate,
+	"deploy/compose-prod/Caddyfile":        deployComposeProdCaddyfileTemplate,
+	"deploy/compose-prod/deploy.sh":        deployComposeProdDeployShTemplate,
+	"deploy/compose-prod/backup.sh":        deployComposeProdBackupShTemplate,
+	"deploy/compose-prod/systemd.service":  deployComposeProdSystemdTemplate,
+	"deploy/compose-prod/README.md":        deployComposeProdReadmeTemplate,
 }
 
 // BootstrapTemplateHash returns the content hash of the registered template

--- a/workshop/codegen/generators/deploy.go
+++ b/workshop/codegen/generators/deploy.go
@@ -10,7 +10,7 @@ import (
 
 // DeployTargets lists the deploy profiles `gopernicus new deploy` can emit,
 // in recommendation order.
-var DeployTargets = []string{"do-app", "cloud-run"}
+var DeployTargets = []string{"do-app", "cloud-run", "compose-prod"}
 
 // deployProfiles maps each target to the files it emits. Workflow files
 // must live under .github/workflows/ to fire; everything else lives under
@@ -26,15 +26,24 @@ var deployProfiles = map[string][]deployFile{
 		{relPath: "workshop/deploy/cloud-run/makefile.cloud-run", kind: "deploy/cloud-run/makefile.cloud-run", altDelims: true},
 		{relPath: "workshop/deploy/cloud-run/README.md", kind: "deploy/cloud-run/README.md"},
 	},
+	"compose-prod": {
+		{relPath: "workshop/deploy/compose-prod/compose.prod.yml", kind: "deploy/compose-prod/compose.prod.yml"},
+		{relPath: "workshop/deploy/compose-prod/caddy/Caddyfile", kind: "deploy/compose-prod/Caddyfile"},
+		{relPath: "workshop/deploy/compose-prod/deploy.sh", kind: "deploy/compose-prod/deploy.sh", executable: true},
+		{relPath: "workshop/deploy/compose-prod/backup.sh", kind: "deploy/compose-prod/backup.sh", executable: true},
+		{relPath: "workshop/deploy/compose-prod/systemd/%s-compose.service", kind: "deploy/compose-prod/systemd.service"},
+		{relPath: "workshop/deploy/compose-prod/README.md", kind: "deploy/compose-prod/README.md"},
+	},
 }
 
 // deployFile is one emitted profile file. relPath may carry one %s, filled
 // with the project name. altDelims selects [[ ]] template delimiters for
 // payloads whose syntax collides with {{ }} (GitHub Actions, make).
 type deployFile struct {
-	relPath   string
-	kind      string
-	altDelims bool
+	relPath    string
+	kind       string
+	altDelims  bool
+	executable bool
 }
 
 // DeployData is the template data for deploy profile files.
@@ -82,7 +91,11 @@ func GenerateDeployProfile(root, target string, data DeployData) error {
 			return fmt.Errorf("creating directory for %s: %w", rel, err)
 		}
 		out := prependBootstrapMarkerStyled(f.kind, rel, buf.Bytes())
-		if err := os.WriteFile(dst, out, 0o644); err != nil {
+		mode := os.FileMode(0o644)
+		if f.executable {
+			mode = 0o755
+		}
+		if err := os.WriteFile(dst, out, mode); err != nil {
 			return fmt.Errorf("writing %s: %w", rel, err)
 		}
 		fmt.Printf("  ✓ %s\n", rel)

--- a/workshop/codegen/generators/deploy_composeprod_tmpl.go
+++ b/workshop/codegen/generators/deploy_composeprod_tmpl.go
@@ -1,0 +1,280 @@
+package generators
+
+// compose-prod deploy profile templates: the "$10 VPS" story. One compose
+// file runs app + postgres + redis + caddy (automatic TLS); deploy.sh
+// builds, migrates (in a one-off golang container — the VPS needs no Go
+// toolchain), and rolls the app; a systemd unit keeps the stack up across
+// reboots; backup.sh + cron rotate pg dumps.
+
+// deployComposeProdComposeTemplate produces
+// workshop/deploy/compose-prod/compose.prod.yml.
+const deployComposeProdComposeTemplate = `# Production compose stack for {{.ProjectName}}.
+# Interpolated variables (POSTGRES_PASSWORD, SITE_ADDRESS) come from the
+# environment — deploy.sh sources .env.prod at the repo root.
+name: {{.ProjectName}}-prod
+
+services:
+  app:
+    build:
+      context: ../../..
+      dockerfile: workshop/docker/dockerfile.{{.ProjectName}}
+      args:
+        BUILD_REF: ${BUILD_REF:-dev}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
+    restart: unless-stopped
+    env_file:
+      - ../../../.env.prod
+    # Published on loopback only — public traffic enters through caddy.
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: {{.ProjectName}}
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.prod}
+      PGDATA: /data/postgres
+    volumes:
+      - postgres-data:/data/postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # Drop this service (and the app depends_on entry) if the app was
+  # scaffolded without redis.
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      SITE_ADDRESS: ${SITE_ADDRESS:?set SITE_ADDRESS in .env.prod (your domain, or :80 for plain HTTP)}
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - app
+
+  # One-off migration runner (profile-gated: never starts with 'up').
+  # Runs the project's pinned generator tool, so the VPS needs no Go
+  # toolchain — deploy.sh invokes it as a release step, never at boot.
+  migrate:
+    image: golang:1.26
+    profiles: ["deploy"]
+    working_dir: /src
+    environment:
+      {{.AppNameUpper}}_DB_DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/{{.ProjectName}}?sslmode=disable
+      GOFLAGS: -mod=mod
+    volumes:
+      - ../../..:/src
+      - go-mod-cache:/go/pkg/mod
+    command: go tool gopernicus db migrate
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres-data:
+  redis-data:
+  caddy-data:
+  caddy-config:
+  go-mod-cache:
+`
+
+// deployComposeProdCaddyfileTemplate produces
+// workshop/deploy/compose-prod/caddy/Caddyfile.
+const deployComposeProdCaddyfileTemplate = `# Caddy fronts the app with automatic TLS. SITE_ADDRESS is the served
+# address from .env.prod: a domain (yourapp.example.com) gets a Let's
+# Encrypt certificate automatically; ":80" serves plain HTTP for
+# local smoke tests (port 80 is the published HTTP port).
+{$SITE_ADDRESS}
+
+reverse_proxy app:3000
+`
+
+// deployComposeProdDeployShTemplate produces
+// workshop/deploy/compose-prod/deploy.sh.
+const deployComposeProdDeployShTemplate = `#!/usr/bin/env bash
+# Deploy {{.ProjectName}} on this host: build -> migrate -> roll the app.
+# Run from anywhere; operates on the repo this script lives in.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE="docker compose -f $ROOT/workshop/deploy/compose-prod/compose.prod.yml"
+
+cd "$ROOT"
+
+if [[ ! -f .env.prod ]]; then
+    echo "missing $ROOT/.env.prod — copy .env.example, set production values" >&2
+    exit 1
+fi
+set -a
+# shellcheck disable=SC1091
+source .env.prod
+set +a
+
+BUILD_REF="$(git rev-parse --short HEAD 2>/dev/null || echo dev)"
+BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+export BUILD_REF BUILD_DATE
+
+echo "==> building app image (${BUILD_REF})"
+$COMPOSE build app
+
+echo "==> starting database"
+$COMPOSE up -d postgres
+
+echo "==> running migrations (release step — a failure stops the deploy)"
+$COMPOSE run --rm migrate
+
+echo "==> rolling the stack"
+$COMPOSE up -d
+
+echo "==> waiting for readiness"
+for _ in $(seq 1 30); do
+    if curl -fsS --max-time 2 http://127.0.0.1:3000/readyz >/dev/null 2>&1; then
+        echo "==> deployed ${BUILD_REF}: $(curl -fsS --max-time 2 http://127.0.0.1:3000/healthz)"
+        exit 0
+    fi
+    sleep 2
+done
+echo "app never became ready — check: $COMPOSE logs app" >&2
+exit 1
+`
+
+// deployComposeProdBackupShTemplate produces
+// workshop/deploy/compose-prod/backup.sh.
+const deployComposeProdBackupShTemplate = `#!/usr/bin/env bash
+# Nightly pg_dump with 14-day rotation. Wire it to cron (see README):
+#   0 3 * * * /path/to/repo/workshop/deploy/compose-prod/backup.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE="docker compose -f $ROOT/workshop/deploy/compose-prod/compose.prod.yml"
+BACKUP_DIR="${BACKUP_DIR:-$ROOT/backups}"
+KEEP_DAYS="${KEEP_DAYS:-14}"
+
+# Compose interpolates POSTGRES_PASSWORD/SITE_ADDRESS even for exec.
+set -a
+# shellcheck disable=SC1091
+source "$ROOT/.env.prod"
+set +a
+
+mkdir -p "$BACKUP_DIR"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+
+$COMPOSE exec -T postgres pg_dump -U postgres {{.ProjectName}} | gzip > "$BACKUP_DIR/{{.ProjectName}}-$STAMP.sql.gz"
+find "$BACKUP_DIR" -name '{{.ProjectName}}-*.sql.gz' -mtime "+$KEEP_DAYS" -delete
+
+echo "backup written: $BACKUP_DIR/{{.ProjectName}}-$STAMP.sql.gz"
+`
+
+// deployComposeProdSystemdTemplate produces
+// workshop/deploy/compose-prod/systemd/<app>-compose.service.
+const deployComposeProdSystemdTemplate = `# Keeps the {{.ProjectName}} compose stack up across reboots.
+# Install (see README): copy to /etc/systemd/system/, fix WorkingDirectory,
+# then: systemctl enable --now {{.ProjectName}}-compose
+[Unit]
+Description={{.ProjectName}} production compose stack
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+# Set these to wherever the repo is checked out on the host. The env file
+# provides the compose interpolation vars (POSTGRES_PASSWORD, SITE_ADDRESS).
+WorkingDirectory=/opt/{{.ProjectName}}
+EnvironmentFile=/opt/{{.ProjectName}}/.env.prod
+ExecStart=/usr/bin/docker compose -f workshop/deploy/compose-prod/compose.prod.yml up -d
+ExecStop=/usr/bin/docker compose -f workshop/deploy/compose-prod/compose.prod.yml down
+
+[Install]
+WantedBy=multi-user.target
+`
+
+// deployComposeProdReadmeTemplate produces
+// workshop/deploy/compose-prod/README.md.
+const deployComposeProdReadmeTemplate = `# Deploying {{.ProjectName}} with compose on a single host
+
+The "$10 VPS" profile: one compose file runs the app, postgres, redis,
+and caddy (automatic TLS). No registry, no orchestrator — the host
+builds from the checked-out repo. Requirements on the host: docker (with
+compose), git, curl. No Go toolchain — migrations run in a one-off
+golang container.
+
+## One-time setup
+
+1. Check out the repo on the host (the systemd unit assumes
+   ` + "`/opt/{{.ProjectName}}`" + `; adjust if elsewhere).
+2. Create ` + "`.env.prod`" + ` at the repo root (gitignored — never commit it).
+   Start from ` + "`.env.example`" + ` and set at least:
+
+       POSTGRES_PASSWORD=<strong-password>
+       SITE_ADDRESS=yourapp.example.com   # or :80 for plain HTTP
+       {{.AppNameUpper}}_DB_DATABASE_URL=postgres://postgres:<strong-password>@postgres:5432/{{.ProjectName}}?sslmode=disable
+       {{.AppNameUpper}}_REDIS_ADDR=redis:6379
+
+   Hostnames are compose service names (` + "`postgres`" + `, ` + "`redis`" + `) — the app
+   reaches them on the compose network.
+3. Point your domain's DNS at the host; caddy provisions TLS on first
+   request. (No domain yet? ` + "`SITE_ADDRESS=:80`" + ` serves plain HTTP.)
+4. Install the systemd unit so the stack survives reboots:
+
+       sudo cp workshop/deploy/compose-prod/systemd/{{.ProjectName}}-compose.service /etc/systemd/system/
+       # edit WorkingDirectory if the repo is not at /opt/{{.ProjectName}}
+       sudo systemctl enable --now {{.ProjectName}}-compose
+
+5. Schedule backups (nightly pg_dump, 14-day rotation):
+
+       crontab -e
+       0 3 * * * /opt/{{.ProjectName}}/workshop/deploy/compose-prod/backup.sh
+
+## Deploying
+
+    git pull --ff-only
+    ./workshop/deploy/compose-prod/deploy.sh
+
+The script builds the image (stamped with the commit as ` + "`BUILD_REF`" + ` —
+visible in startup logs and ` + "`/healthz`" + `), runs migrations as a **release
+step** (a bad migration stops the deploy; the running app keeps serving),
+rolls the stack, and waits for ` + "`/readyz`" + `.
+
+## Probes & monitoring
+
+- ` + "`/healthz`" + ` — liveness, dependency-free, reports the running build.
+- ` + "`/readyz`" + ` — readiness, pings postgres.
+
+Both are reachable on the host at ` + "`127.0.0.1:3000`" + ` (loopback only;
+public traffic enters through caddy).
+
+## Rollback
+
+    git checkout <previous-good-sha>
+    ./workshop/deploy/compose-prod/deploy.sh
+
+Migrations are forward-only — restore from ` + "`backups/`" + ` for schema
+rollback:
+
+    gunzip -c backups/{{.ProjectName}}-<stamp>.sql.gz | \
+      docker compose -f workshop/deploy/compose-prod/compose.prod.yml \
+      exec -T postgres psql -U postgres {{.ProjectName}}
+`

--- a/workshop/codegen/generators/deploy_test.go
+++ b/workshop/codegen/generators/deploy_test.go
@@ -141,3 +141,54 @@ func TestStyledMarkers(t *testing.T) {
 		t.Errorf("marker not on line 2 of shell file: %q", lines[1])
 	}
 }
+
+func TestGenerateDeployProfileComposeProd(t *testing.T) {
+	root := t.TempDir()
+	data := DeployData{ProjectName: "myapp", AppNameUpper: "MYAPP"}
+
+	if err := GenerateDeployProfile(root, "compose-prod", data); err != nil {
+		t.Fatal(err)
+	}
+
+	base := filepath.Join(root, "workshop", "deploy", "compose-prod")
+	for _, rel := range []string{
+		"compose.prod.yml", "caddy/Caddyfile", "deploy.sh", "backup.sh",
+		"systemd/myapp-compose.service", "README.md",
+	} {
+		if _, err := os.Stat(filepath.Join(base, rel)); err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+		}
+	}
+
+	// Shell scripts: shebang on line 1, marker on line 2, executable.
+	for _, sh := range []string{"deploy.sh", "backup.sh"} {
+		body, err := os.ReadFile(filepath.Join(base, sh))
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.SplitN(string(body), "\n", 3)
+		if !strings.HasPrefix(lines[0], "#!") {
+			t.Errorf("%s: line 1 = %q, want shebang", sh, lines[0])
+		}
+		if _, _, ok := ParseBootstrapMarker(lines[1]); !ok {
+			t.Errorf("%s: line 2 = %q, want marker", sh, lines[1])
+		}
+		info, _ := os.Stat(filepath.Join(base, sh))
+		if info.Mode()&0o111 == 0 {
+			t.Errorf("%s not executable: %v", sh, info.Mode())
+		}
+	}
+
+	compose, _ := os.ReadFile(filepath.Join(base, "compose.prod.yml"))
+	for _, want := range []string{
+		"dockerfile.myapp",
+		"MYAPP_DB_DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/myapp",
+		"go tool gopernicus db migrate",
+		`profiles: ["deploy"]`,
+		"BUILD_REF: ${BUILD_REF:-dev}",
+	} {
+		if !strings.Contains(string(compose), want) {
+			t.Errorf("compose missing %q", want)
+		}
+	}
+}

--- a/workshop/documentation/docs/cli/new.md
+++ b/workshop/documentation/docs/cli/new.md
@@ -285,14 +285,16 @@ Emit a deploy profile for one hosting target: a runbook plus the pipeline
 files that ship the app there.
 
 ```bash
-gopernicus new deploy do-app      # DigitalOcean App Platform
-gopernicus new deploy cloud-run   # Google Cloud Run
+gopernicus new deploy do-app        # DigitalOcean App Platform
+gopernicus new deploy cloud-run     # Google Cloud Run
+gopernicus new deploy compose-prod  # single host: compose + caddy + systemd
 ```
 
 | Target | Style | Files |
 |---|---|---|
 | `do-app` | CI-driven | `.github/workflows/deploy-<app>-do.yml` (tag-triggered: ghcr build → migrate as release step → DO app refresh), `workshop/deploy/do-app/app-spec.yaml`, README runbook |
 | `cloud-run` | make-driven | `workshop/deploy/cloud-run/makefile.cloud-run` (`cloud-bootstrap` / `cloud-build` / `cloud-migrate` / `cloud-deploy` / `cloud-ship` / `cloud-url` / `cloud-logs`; include it from the root Makefile), README runbook |
+| `compose-prod` | host-driven | `workshop/deploy/compose-prod/`: `compose.prod.yml` (app + postgres + redis + caddy TLS), `deploy.sh` (build → migrate → roll → readiness wait), `caddy/Caddyfile`, `systemd/<app>-compose.service`, `backup.sh`, README runbook |
 
 Everything emitted is a **created-once bootstrap with a drift marker** —
 you own the files after emission; re-running skips existing files.

--- a/workshop/documentation/docs/gopernicus/topics/deployment.md
+++ b/workshop/documentation/docs/gopernicus/topics/deployment.md
@@ -15,6 +15,7 @@ re-running never overwrites.
 |---|---|
 | `do-app` | DigitalOcean App Platform: tag-triggered GitHub workflow — ghcr image build, migrations as a release step, app refresh — plus a reference app spec |
 | `cloud-run` | Google Cloud Run: make targets (`cloud-bootstrap`, `cloud-build`, `cloud-migrate`, `cloud-deploy`, `cloud-ship`) included from the root Makefile |
+| `compose-prod` | Single host ("the $10 VPS"): compose stack (app + postgres + redis + caddy with automatic TLS), `deploy.sh` (build → migrate → roll → readiness wait), systemd unit, pg backup script + cron |
 
 Each target's README is the runbook: one-time setup, deploy procedure,
 rollback notes.

--- a/workshop/gopernicus/commands/new.go
+++ b/workshop/gopernicus/commands/new.go
@@ -69,6 +69,9 @@ Targets:
              app spec
   cloud-run  Google Cloud Run — make targets (include from the root
              Makefile): bootstrap, build, migrate, deploy, url, logs
+  compose-prod
+             Single host — compose stack (app+postgres+redis+caddy TLS),
+             deploy.sh, systemd unit, pg backup cron
 
 Files land in workshop/deploy/<target>/ (workflows in .github/workflows/).
 Everything is created-once with a drift marker — you own the files after
@@ -77,7 +80,8 @@ a sibling directory.
 
 Examples:
   gopernicus new deploy do-app
-  gopernicus new deploy cloud-run`,
+  gopernicus new deploy cloud-run
+  gopernicus new deploy compose-prod`,
 			Usage: "gopernicus new deploy <target>",
 			Run:   runNewDeploy,
 		},


### PR DESCRIPTION
Final deploy target (B2) of the v0.5.x ops plan — closes the deploy-profiles milestone (do-app + cloud-run + probe contract landed in #51).

`gopernicus new deploy compose-prod` emits the "$10 VPS" pipeline: `compose.prod.yml` (app from the repo dockerfile + postgres + redis + caddy automatic TLS, app on loopback only), `deploy.sh` (build → migrate → roll → wait for `/readyz`), `caddy/Caddyfile`, an `EnvironmentFile`-aware systemd unit, and `backup.sh` (pg_dump with rotation). Migrations run in a one-off profile-gated golang container, so the host needs docker/git/curl but no Go toolchain — migrate-never-at-boot on a single box.

**Acceptance (live):** verified on a synthetic consumer pinned to published v0.5.3 — `deploy.sh` booted the full stack from scratch, the migrate container applied against the compose postgres, `/healthz` (with build stamp) and `/readyz` answered through caddy on :80, `backup.sh` produced a real dump. Two real bugs found and fixed by running it (backup.sh env interpolation; systemd EnvironmentFile).

Everything emitted is created-once with a drift marker; the profile never modifies existing files. Branch builds clean; deploy generator tests green.