### PR TITLE
docs: fix stale cli and framework reference drift

### DIFF
--- a/workshop/documentation/docs/cli/boot.md
+++ b/workshop/documentation/docs/cli/boot.md
@@ -49,11 +49,18 @@ gopernicus boot repos [domain] [--db <name>]
 3. For each database, reads the `domains` map. If a domain filter is provided,
    only that domain is processed; otherwise all domains are iterated in
    alphabetical order.
-4. For each table in a domain:
-   - **Skips** if `core/repositories/<domain>/<table>/queries.sql` already exists.
+4. For each table in a domain (the repo directory uses the package-normalized
+   table name -- lowercased with underscores stripped -- so table `api_keys`
+   scaffolds to `core/repositories/<domain>/apikeys/`, not `api_keys`):
+   - **Skips** if `core/repositories/<domain>/<package-normalized-table>/queries.sql`
+     already exists.
+   - **Skips** (with a `spec-shipped with the framework` notice) feature entities
+     whose `queries.sql` spec ships with the framework -- create
+     `core/repositories/<domain>/<package-normalized-table>/queries.sql` by hand to
+     eject the shipped spec.
    - Looks up the table in the reflected schema JSON (`_public.json`).
    - **Skips** with a warning if the table is not found in the reflected schema.
-   - Calls the same `scaffoldRepoForTable` and `scaffoldBridgeYMLForTable`
+   - Calls the same `scaffold.RepoForTable` and `scaffold.BridgeYMLForTable`
      functions used by `gopernicus new repo` to create the repo directory,
      `queries.sql`, and `bridge.yml`.
 5. Prints a summary of how many repos were scaffolded and next steps.
@@ -103,7 +110,7 @@ Running `gopernicus boot repos` scaffolds repos for all three domains.
 ### Error Handling
 
 - If a domain filter is provided but not found in the specified database, the
-  command fails with an error listing the available domains.
+  command fails with an error listing the defined domains.
 - If a table is not found in the reflected schema, that table is skipped with a
   warning (not a fatal error). Run `gopernicus db reflect` to update the schema.
 - If all repos already exist, the command reports "No new repos to scaffold."

--- a/workshop/documentation/docs/cli/generate.md
+++ b/workshop/documentation/docs/cli/generate.md
@@ -4,10 +4,12 @@ Run code generators from `queries.sql` files and `bridge.yml` configuration.
 
 ## Overview
 
-`gopernicus generate` scans `core/repositories/` for `queries.sql` files and
-`bridge/repositories/` for `bridge.yml` files, then generates Go code by
-cross-referencing each query with the reflected database schema (produced by
-`gopernicus db reflect`).
+`gopernicus generate` is driven by the `gopernicus.yml` manifest domain mapping
+(`databases.<name>.domains`), iterating database × domain × entity. For each
+declared entity it locates that entity's `queries.sql` (not discovered by
+scanning) and, if present, the entity's `bridge.yml` from its bridge directory,
+then generates Go code by cross-referencing each query with the reflected
+database schema (produced by `gopernicus db reflect`).
 
 The generator produces two categories of files:
 
@@ -29,7 +31,7 @@ gopernicus generate [domain] [--dry-run] [--verbose] [--force-bootstrap]
 
 | Argument | Description |
 |---|---|
-| `[domain]` | Optional. Restrict generation to a single domain (e.g. `auth`). When omitted, all domains under `core/repositories/` are processed. |
+| `[domain]` | Optional. Restrict generation to a single domain (e.g. `auth`). When omitted, all domains declared in the manifest are processed. |
 
 ### Flags
 
@@ -81,7 +83,7 @@ triggers generation in the repository, store, bridge, and test layers.
 | `generated_test.go` | Always | Yes | Auto-generated `Create` / `Get` / `List` / `Delete` / `SoftDelete` smoke tests. `-- @skip-integration-test` at the top of `queries.sql` suppresses the probes — the file is regenerated setup-only (just the `setupTestStore` helper). |
 | `store_test.go` | Once | No | `setupTestStore` helper plus `migrateTestDB` and `testPGXOptions` hooks for the test container. |
 
-**Cache** (`core/repositories/<domain>/<entity>/`) -- only when `@cache` annotations are present:
+**Cache** (`core/repositories/<domain>/<entity>/`) -- always emitted per entity (the wrapper is generated even with no `@cache` annotations so adding caching later is just a regenerate; `@cache` annotations only determine which methods become cache-aware):
 
 | File | Created | Overwritten | Description |
 |---|---|---|---|
@@ -128,13 +130,12 @@ triggers generation in the repository, store, bridge, and test layers.
 | `generated.go` | Always | Yes | Factory functions for creating test entities with resolved FK relationships. **Cumulative across all domains** — `gopernicus generate <one-domain>` rewrites the file with every entity's fixtures, not just the targeted domain's, so cross-domain FK chains continue to resolve. |
 | `fixtures.go` | Once | No | Custom fixture helpers and overrides. |
 
-**E2E Tests** (`workshop/testing/e2e/`) -- for entities with HTTP routes:
+**E2E Tests** (`bridge/repositories/<domain>reposbridge/<entity>bridge/`) -- for entities with HTTP routes:
 
 | File | Created | Overwritten | Description |
 |---|---|---|---|
-| `setup_test.go` | Once | No | E2E test bootstrap (server setup, database connection). One per project. |
-| `<entity>_generated_test.go` | Always | Yes | Auto-generated HTTP roundtrip tests per entity. |
-| `<entity>_test.go` | Once | No | Custom E2E test cases per entity. |
+| `generated_e2e_test.go` | Always | Yes | Auto-generated HTTP roundtrip tests per entity, emitted into the entity's bridge directory. |
+| `e2e_test.go` | Once | No | Custom E2E test cases per entity. |
 
 With `--force-bootstrap`, all "Once / No" files are regenerated from scratch.
 
@@ -200,8 +201,9 @@ vim bridge/repositories/catalogreposbridge/widgetsbridge/bridge.yml
 ## Notes
 
 - The generator requires the project root to contain a `gopernicus.yml`
-  manifest. It uses `project.MustFindRoot()` to locate it by walking up from
-  the current directory.
+  manifest. It uses `project.MustFindRoot()` to locate the project root by
+  walking up from the current directory until it finds a `go.mod` file; the
+  `gopernicus.yml` manifest is then expected at that root.
 - If the reflected schema is missing or stale, generated types may be incorrect.
   Always re-reflect after schema changes.
 - Generated files contain a header comment indicating they are auto-generated.

--- a/workshop/documentation/docs/cli/init.md
+++ b/workshop/documentation/docs/cli/init.md
@@ -29,34 +29,23 @@ gopernicus init <project-name> [--module <path>] [--framework-version <version>]
 |---|---|
 | `--module`, `-m` | Go module path (e.g. `github.com/acme/myapp`). Inferred from org/repo shorthand if omitted. When neither shorthand nor flag is provided, defaults to `github.com/your-org/<project-name>`. |
 | `--framework-version` | Pin a specific gopernicus framework version (e.g. `v0.1.0`). When omitted, fetches `@latest`. |
-| `--no-interactive` | Skip interactive prompts. Uses all-features-enabled and default infrastructure when combined with no `--features` flag. |
+| `--no-interactive` | Accepted for compatibility. `init` is always non-interactive; omitted flags fall back to defaults (all features, default infrastructure). |
 | `--features <list>` | Comma-separated feature list. Valid values: `authentication`, `authorization`, `tenancy`, `event-outbox`, `job-queue`, `all`, `none`. Default when omitted in non-interactive mode: `all`. |
 
-## Interactive Prompts
+## Feature & Infrastructure Selection
 
-When run without `--no-interactive` (and stdin is a terminal), init launches a
-multi-step TUI wizard:
+`gopernicus init` is fully flag-driven -- it does **not** launch a TUI wizard.
+Even when `--no-interactive` is omitted, the command runs with defaults (printing
+a note that it is using defaults; pass `--features`/`--module` to customize).
+Omitted flags resolve to:
 
-1. **Project name** -- defaults to the positional argument.
-2. **Go module path** -- defaults to `github.com/<org>/<project>` or `github.com/your-org/<project>`.
-3. **Framework Features** -- multi-select picker, all selected by default:
-   - Authentication (users, sessions, OAuth, API keys)
-   - Authorization (ReBAC relationships, permissions)
-   - Tenancy (multi-tenant isolation, groups)
-4. **Event Infrastructure** -- separate picker screen, both selected by default:
-   - Event Outbox (transactional outbox for atomic event delivery)
-   - Job Queue (durable deferred processing with retry and dead-lettering)
-5. **Infrastructure Adapters** -- four separate picker screens:
-   - Cache Backend (Redis Cache -- selected by default)
-   - Event Bus Backend (Redis Streams -- selected by default)
-   - File Storage (Disk and GCS selected by default, S3 unselected)
-   - Email Delivery (SendGrid -- selected by default)
-6. **AI Companion** -- multi-select picker:
-   - Claude (selected by default) -- generates CLAUDE.md with project conventions and .claude/skills/ with workflow skills for common tasks (generate, new-entity, new-case, migrate)
-
-If `--features` is provided on the CLI alongside interactive mode, the feature
-picker is skipped and the flag value is used. The infrastructure picker always
-runs in interactive mode.
+- **Features** -- all features enabled: `authentication`, `authorization`,
+  `tenancy`, `event-outbox`, `job-queue`. Override with `--features`.
+- **Infrastructure** -- the default adapter set (see
+  [Non-Interactive Infrastructure Defaults](#non-interactive-infrastructure-defaults)
+  below).
+- **AI companion** -- Claude, which generates `CLAUDE.md` with project
+  conventions and `.claude/skills/` with workflow skills for common tasks.
 
 ## What Gets Created
 
@@ -77,17 +66,15 @@ The scaffolding process executes these steps in order:
    - `bridge/transit/`
    - `infrastructure/`
    - `sdk/`
-4. **gopernicus.yml** -- manifest file with feature flags and domain-to-table mappings. Includes `gopernicus_version` if `--framework-version` was provided.
+4. **gopernicus.yml** -- manifest file with feature flags and domain-to-table mappings. Always includes `gopernicus_version`, defaulting to `latest`; when `--framework-version` is provided it is set to that pinned version instead.
 5. **.gitignore** -- standard Go gitignore with env file exclusions.
 6. **App server scaffold** -- `cmd/`, `app/`, and server wiring code generated from templates. Infrastructure adapters are included based on picker selections.
-7. **Feature assets** -- when at least one feature is selected, the CLI copies migrations, core repositories, bridge repositories, and satisfiers from the gopernicus framework source. Source files are resolved from the Go module cache (or from `GOPERNICUS_DEV_SOURCE` in dev mode). Copied Go files have their import paths rewritten from the gopernicus module to your module path for `core/repositories/`, `core/auth/*/satisfiers`, and `bridge/repositories/` imports. Framework SDK and infrastructure imports are left pointing at gopernicus.
-   - SQL migrations (`0001_auth.sql`, `0002_rebac.sql`, `0003_tenants.sql`, `0004_event_outbox.sql`, `0005_job_queue.sql`)
+7. **Feature assets** -- when at least one feature is selected, the CLI copies migrations, core repositories, and bridge repositories from the gopernicus framework source. Source files are resolved from the Go module cache (or from `GOPERNICUS_DEV_SOURCE` in dev mode). Copied Go files have their import paths rewritten from the gopernicus module to your module path for `core/repositories/` and `bridge/repositories/` imports. Framework SDK and infrastructure imports are left pointing at gopernicus.
+   - SQL migrations (`0001_auth.sql`, `0002_rebac.sql`, `0003_tenants.sql`, `0004_event_outbox.sql`, `0005_job_queue.sql`, `0006_job_schedules.sql`)
    - Core repositories (`core/repositories/auth/`, `core/repositories/rebac/`, `core/repositories/tenancy/`, etc.)
    - Bridge repositories (`bridge/repositories/authreposbridge/`, `bridge/repositories/rebacreposbridge/`, `bridge/repositories/tenancyreposbridge/`)
-   - Authentication satisfiers (`core/auth/authentication/satisfiers/`)
-   - Authorization satisfiers (`core/auth/authorization/satisfiers/`)
-   - Authentication bridge (`bridge/auth/authentication/`)
-   - Invitations bridge (`bridge/auth/invitations/`)
+   - Authentication and authorization satisfiers (`core/auth/authentication/satisfiers/`, `core/auth/authorization/satisfiers/`) are **generated** by the post-init `gopernicus generate` step, not copied.
+   - The authentication and invitations bridges (`bridge/auth/authentication/`, `bridge/auth/invitations/`) are **imported** from the framework rather than copied.
 8. **AI companion files** -- when Claude is selected:
    - `CLAUDE.md` -- project instructions with architecture overview, conventions, key paths, and common commands
    - `.claude/skills/new-domain.md` -- interactive workflow: design tables, write migrations, scaffold repos, generate, and wire a new domain
@@ -106,7 +93,7 @@ domain-to-table mappings:
 | `rebac` | groups, invitations, rebac_relationships, rebac_relationship_metadata |
 | `tenancy` | tenants |
 | `events` | event_outbox |
-| `jobs` | job_queue |
+| `jobs` | job_queue, job_schedules |
 
 ### Non-Interactive Infrastructure Defaults
 
@@ -121,11 +108,12 @@ enabled by default (matching the docker-compose development setup):
 | GCS | enabled |
 | S3 | disabled |
 | SendGrid | enabled |
+| Telemetry | enabled |
 
 ## Examples
 
 ```bash
-# Interactive wizard (recommended for first-time setup)
+# Uses defaults for all features and infrastructure (recommended for first-time setup)
 gopernicus init myapp
 
 # Shorthand with org -- infers module path github.com/acme/myapp

--- a/workshop/documentation/docs/cli/new.md
+++ b/workshop/documentation/docs/cli/new.md
@@ -50,8 +50,11 @@ gopernicus new repo <domain/entity> [--db <name>] [--table <name>]
 ### Scaffolded queries.sql
 
 The generated `queries.sql` includes data annotation comments that drive code
-generation. Only data annotations appear here (`@func`, `@filter`, `@search`,
-`@order`, `@max`, `@fields`, `@cache`, `@event`). The scaffolded operations include:
+generation. Only data annotations appear here. The scaffolder emits `@func`,
+`@filter`, `@search`, `@order`, `@max`, `@fields`, and `@returns` (on
+`GetIDBySlug`); other data annotations such as `@cache` and `@event` are
+available to add manually but are not auto-generated. The scaffolded operations
+include:
 
 - **List** -- paginated, filterable, searchable (string columns).
 - **Get** -- by primary key.
@@ -86,11 +89,13 @@ An entity can have both tenant and parent (e.g. takes), just tenant (e.g. questi
 
 The scaffolder finds text/string columns and adds them to a `@search: ilike(...)` annotation on the List query. Columns named with `hash`, `secret`, `token`, `password`, or `key_prefix` are excluded from search.
 
-### UniqueToID Middleware
+### Slug Awareness
 
-If the table has a unique `slug` column, the scaffold generates `unique_to_id`
-middleware in `bridge.yml` for routes that accept the entity ID parameter. This
-enables clients to use either the ID or the slug in URLs.
+If the table has a unique `slug` column, the scaffolder is slug-aware in
+`queries.sql`, emitting `GetBySlug` / `GetIDBySlug` queries. It does **not**
+auto-generate `unique_to_id` middleware. `unique_to_id` is a valid `bridge.yml`
+middleware type you can add by hand if you want clients to use either the ID or
+the slug in URLs.
 
 ### Examples
 

--- a/workshop/documentation/docs/gopernicus/app/overview.md
+++ b/workshop/documentation/docs/gopernicus/app/overview.md
@@ -186,13 +186,13 @@ Event subscribers are registered in `server.New()` after the event bus and domai
 
 ```go
 // Authentication email subscriber
-authSubs := authbridge.NewSubscribers(mailer, log, frontendURL)
+authSubs := authbridge.NewSubscribers(mailer, log)
 authSubs.Register(bus)
 
 // Invitation auto-resolve subscriber. The user lookup rides the generated
-// authentication users satisfier; add invbridge.WithEmailer(mailer) to also
+// authentication users satisfier; add invitationsbridge.WithEmailer(mailer) to also
 // deliver invitation emails.
-invitationSubs := invbridge.NewSubscribers(inviter, satisfiers.NewUserSatisfier(authRepos.Users), log)
+invitationSubs := invitationsbridge.NewSubscribers(inviter, authenticationsatisfiers.NewUserSatisfier(authRepos.User), log)
 invitationSubs.Register(bus)
 ```
 
@@ -228,6 +228,6 @@ Beyond the Go code, `gopernicus init` also generates:
 |---|---|
 | `.env.example` | Configuration reference with all env vars and defaults |
 | `Makefile` | Development targets: `dev`, `run`, `build`, `test`, `dev-up`, `dev-down`, `dev-psql` |
-| `docker-compose.yml` | Local dev infrastructure (PostgreSQL, Redis if configured) |
-| `Dockerfile` | Multi-stage production build (Go build → Alpine runtime) |
+| `workshop/dev/docker-compose.yml` | Local dev infrastructure (PostgreSQL, Redis if configured) |
+| `workshop/docker/dockerfile.<project-name>` | Multi-stage production build (Go build → Alpine runtime) |
 | `.air.toml` | Hot-reload configuration for development |

--- a/workshop/documentation/docs/gopernicus/bridge/auth/authentication.md
+++ b/workshop/documentation/docs/gopernicus/bridge/auth/authentication.md
@@ -168,19 +168,11 @@ If `callbackBaseURL` is empty, returns nil (no allowlist configured).
 Construction and registration:
 
 ```go
-// Derive fallback URL for email links from first allowed frontend.
-// In strict mode (ALLOWED_FRONTENDS set), reset_url is required in requests
-// and this fallback is not used. Pass empty string if not needed.
-var frontendURL string
-if len(cfg.Auth.AllowedFrontends) > 0 {
-    frontendURL = cfg.Auth.AllowedFrontends[0]
-}
-
-subs := authbridge.NewSubscribers(emailer, log, frontendURL)
+subs := authbridge.NewSubscribers(emailer, log)
 subs.Register(bus)
 ```
 
-Alternatively, if you already have an `OriginMatcher` instance, use `matcher.Default()` which returns the first origin (canonicalized with explicit port).
+Alternatively, if you already have an `allowlist.Matcher` instance (type `*allowlist.Matcher` from `bridge/transit/allowlist`), use `matcher.Default()` which returns the first origin (canonicalized with explicit port).
 
 Email templates are embedded in the package under `templates/` (HTML + plaintext pairs). Register them with the emailer during app wiring:
 
@@ -198,6 +190,5 @@ emailer.WithContentTemplates("authentication", authbridge.AuthTemplates(), email
 | `model.go` | Request/response types for core auth endpoints |
 | `oauth_model.go` | Request/response types for OAuth endpoints |
 | `cookie.go` | Cookie set/clear helpers |
-| `allowlist.go` | `OriginMatcher` for validating client-supplied URLs |
 | `subscribers.go` | Event subscribers for email delivery |
 | `templates/` | Embedded HTML/text email templates |

--- a/workshop/documentation/docs/gopernicus/bridge/middleware.md
+++ b/workshop/documentation/docs/gopernicus/bridge/middleware.md
@@ -72,7 +72,7 @@ httpmid.Authorize(authorizer, log, jsonErrs, "post", "read",
 
 ### Relationship Tracking
 
-When the authorization check succeeds, the middleware stores which relation granted access in the context. Handlers can retrieve it via `GetRelationship()` — useful for varying behavior based on role (e.g., owners see more fields than viewers).
+When the authorization check succeeds and the authorizer's result includes a granting relation reason, the middleware stores which relation granted access in the context. Handlers can retrieve it via `GetRelationship()`, which returns `(RelationshipInfo, bool)` — the boolean indicates whether a relation was recorded. This is useful for varying behavior based on role (e.g., owners see more fields than viewers).
 
 ### bridge.yml Syntax
 
@@ -314,7 +314,7 @@ Context helpers read values set by middleware. All getters return zero values wh
 | Function | Set By | Returns |
 |---|---|---|
 | `GetClientIP(ctx)` | `TrustProxies` | Resolved client IP |
-| `GetRelationship(ctx)` | `Authorize` | `RelationshipInfo{Relation, ResourceType, ResourceID}` |
+| `GetRelationship(ctx)` | `Authorize` | `(RelationshipInfo{Relation, ResourceType, ResourceID}, bool)` — `bool` reports whether a relation was set |
 | `GetTenantID(ctx)` | `ExtractTenantID` / `InjectDefaultTenant` | Tenant ID |
 | `MustGetTenantID(ctx)` | `ExtractTenantID` / `InjectDefaultTenant` | Tenant ID or panic |
 

--- a/workshop/documentation/docs/gopernicus/bridge/overview.md
+++ b/workshop/documentation/docs/gopernicus/bridge/overview.md
@@ -25,8 +25,9 @@ bridge/
 │   │   ├── apikeysbridge/
 │   │   └── ...
 │   ├── rebacreposbridge/    # ReBAC domain
-│   ├── eventsreposbridge/   # Events domain
 │   └── tenancyreposbridge/  # Tenancy domain
+├── events/                  # Events bridge (server-sent events)
+│   └── ssebridge/
 └── transit/                 # Shared HTTP utilities
     ├── httpmid/             # Middleware (auth, rate limiting, logging, etc.)
     └── fop/                 # Response envelopes, post-filter authorization

--- a/workshop/documentation/docs/gopernicus/bridge/repositories.md
+++ b/workshop/documentation/docs/gopernicus/bridge/repositories.md
@@ -139,7 +139,7 @@ routes:
 
 | Middleware | Syntax | Purpose |
 |---|---|---|
-| `authenticate` | `authenticate: any\|user_only\|service_account_only` | JWT/API key validation |
+| `authenticate` | `authenticate: any\|user\|service_account\|user_session` | JWT/API key validation |
 | `rate_limit` | `rate_limit` | Per-subject rate limiting |
 | `authorize` | `authorize: {permission, param}` | Check permission on specific resource via path param |
 | `authorize` (prefilter) | `authorize: {pattern: prefilter, permission}` | Resolve authorized IDs before querying (for list endpoints) |

--- a/workshop/documentation/docs/gopernicus/core/auth/authorization.md
+++ b/workshop/documentation/docs/gopernicus/core/auth/authorization.md
@@ -160,7 +160,7 @@ result, err := authorizer.Check(ctx, authorization.CheckRequest{
    - **Direct:** queries the store for the relation, with group membership expansion
    - **Through:** traverses the relation to find target resources, then recursively checks the specified permission on each target
 
-The `Reason` field in the result describes which rule granted access (e.g., `"direct:owner"`, `"through:org->direct:admin"`, `"platform:admin"`, `"self:user"`).
+The `Reason` field in the result describes which rule granted access (e.g., `"direct:owner"`, `"through:org->direct:admin"`, `"platform:admin"`, `"self"`).
 
 ### Batch Check
 

--- a/workshop/documentation/docs/gopernicus/core/cases.md
+++ b/workshop/documentation/docs/gopernicus/core/cases.md
@@ -34,8 +34,7 @@ core/cases/
 bridge/cases/
 └── checkoutbridge/
     ├── bridge.go       # Bridge struct, constructor
-    ├── routes.go       # AddHttpRoutes
-    ├── http.go         # HTTP handlers
+    ├── http.go         # AddHttpRoutes + HTTP handlers
     └── model.go        # Request/response models
 ```
 

--- a/workshop/documentation/docs/gopernicus/core/overview.md
+++ b/workshop/documentation/docs/gopernicus/core/overview.md
@@ -20,6 +20,7 @@ core/
 │   │   └── satisfiers/      # Adapters bridging generated repos to authz interfaces
 │   └── invitations/         # Invitation workflow (create, accept, decline)
 ├── cases/                   # Hand-written business logic (user-defined)
+├── jobs/                    # Recurring-job scheduler
 ├── repositories/            # Generated data access
 │   ├── auth/                # Auth domain (users, sessions, apikeys, etc.)
 │   ├── rebac/               # ReBAC domain (groups, invitations, relationships)

--- a/workshop/documentation/docs/gopernicus/design-philosophy.md
+++ b/workshop/documentation/docs/gopernicus/design-philosophy.md
@@ -82,6 +82,7 @@ The same alphabetical convention applies to the top-level packages inside each l
 core/
 ├── auth/ # Authentication, authorization, invitations (framework-provided)
 ├── cases/ # Hand-written business logic (user-defined)
+├── jobs/ # Background job scheduling (framework-provided)
 └── repositories/ # Data access layer
 
 ```
@@ -105,6 +106,7 @@ Cases don't need to import auth. Authorization checks happen at the bridge layer
 bridge/
 ├── auth/ # Framework-provided HTTP auth handlers
 ├── cases/ # User-defined case HTTP handlers
+├── events/ # Framework-provided event streaming (SSE) handlers
 ├── repositories/ # Generated CRUD HTTP handlers
 └── transit/ # HTTP middleware, authorization-aware pagination, error rendering
 

--- a/workshop/documentation/docs/gopernicus/infrastructure/communications/emailer.md
+++ b/workshop/documentation/docs/gopernicus/infrastructure/communications/emailer.md
@@ -42,7 +42,7 @@ Most code depends on `Renderer`, not `Emailer` directly.
 
 ## Emailer
 
-`Emailer` wraps a `Client` and adds template rendering, a default sender address, and branding. It satisfies both `Renderer` and `notify.Notifier`. Structured logging of send failures is opt-in via `WithLogger`:
+`Emailer` wraps a `Client` and adds template rendering, a default sender address, and branding. It satisfies `Renderer` and also exposes a direct `Send` method. Structured logging of send failures is opt-in via `WithLogger`:
 
 ```go
 e, err := emailer.New(

--- a/workshop/documentation/docs/gopernicus/infrastructure/communications/overview.md
+++ b/workshop/documentation/docs/gopernicus/infrastructure/communications/overview.md
@@ -17,4 +17,4 @@ The communications layer handles outbound messaging across delivery channels. Ea
 
 Each channel defines its own `Client` interface suited to that medium — email, SMS, and instant messaging have fundamentally different data requirements and there's no meaningful common abstraction between them.
 
-If your domain needs to send an email, it depends on `emailer.Renderer`. If it needs SMS, it will depend on the SMS client interface. Channels are not interchangeable by design.
+If your domain needs to send an email, it depends on the concrete `*emailer.Emailer` and calls its `RenderAndSend` method (the `emailer.Renderer` interface is the contract `Emailer` satisfies, not the injected dependency type today). If it needs SMS, it will depend on the SMS client interface. Channels are not interchangeable by design.

--- a/workshop/documentation/docs/gopernicus/infrastructure/overview.md
+++ b/workshop/documentation/docs/gopernicus/infrastructure/overview.md
@@ -154,7 +154,7 @@ Use the pattern that matches your situation. Most cases work fine with the gener
 
 Infrastructure packages follow a consistent logging policy based on whether they operate synchronously or asynchronously.
 
-**Asynchronous packages** — those with background goroutines or fire-and-forget paths — require a `*slog.Logger` in their constructor. Errors in async code paths have no caller to return to, so logging is the only way to surface them. This applies to `memorybus`, `goredisbus`, `outbox`, `throttler`, and `tokenbucket`.
+**Asynchronous packages** — those with background goroutines or fire-and-forget paths — require a `*slog.Logger` in their constructor. Errors in async code paths have no caller to return to, so logging is the only way to surface them. This applies to `memorybus.New`, `goredisbus.New`, `throttler.New`, and `throttler.NewTokenBucket`. The `poller` is also asynchronous but takes its logger via the optional `WithLogger` option rather than a required constructor parameter.
 
 **Synchronous packages** offer logging as an opt-in via `WithLogger(*slog.Logger)`. All errors are returned to the caller regardless — logging is purely observational. When a caller passes `WithLogger`, they're saying "log your defaults." When they don't, the package is silent.
 

--- a/workshop/documentation/docs/gopernicus/intro.md
+++ b/workshop/documentation/docs/gopernicus/intro.md
@@ -77,4 +77,4 @@ The project's `go.mod` carries a `tool` directive pinning the generator to the
 same framework version the project links, so generated code and runtime can
 never drift.
 
-See [CLI: init](../cli/init.md) for all initialization options (authentication, authorization, tenancy, events).
+See [CLI: init](../cli/init.md) for all initialization options via the `--features` flag (authentication, authorization, tenancy, event-outbox, job-queue).

--- a/workshop/documentation/docs/gopernicus/sdk/validation.md
+++ b/workshop/documentation/docs/gopernicus/sdk/validation.md
@@ -38,7 +38,7 @@ errs.Add(validation.Email("email", req.Email))
 
 ## Pointer variants
 
-Every validator has a `Ptr` variant that skips validation when the pointer is nil:
+Most string and numeric scalar validators have a `Ptr` variant that skips validation when the pointer is nil (`Required`, `MinLength`, `MaxLength`, `OneOf`, `Email`, `UUID`, `URL`, `Matches`, `Min`, `Max`, `Positive`, `Slug`). For validators without a `Ptr` variant (e.g. `Range`, the collection validators, `PasswordStrength`), wrap them with `IfSet` for optional pointer fields:
 
 ```go
 errs.Add(validation.EmailPtr("email", req.Email))       // *string, nil passes

--- a/workshop/documentation/docs/gopernicus/sdk/web.md
+++ b/workshop/documentation/docs/gopernicus/sdk/web.md
@@ -234,7 +234,7 @@ handler.POST("/generate", func(w http.ResponseWriter, r *http.Request) {
 })
 ```
 
-`AcceptsStream(r)` checks for `text/event-stream` in the `Accept` header. `NewStreamWriter` returns `nil` if the `ResponseWriter` does not support flushing.
+`AcceptsStream(r)` checks for `text/event-stream` in the `Accept` header. `NewStreamWriter` always returns a usable `*StreamWriter`; if the underlying `ResponseWriter` cannot flush, the failure surfaces as an error returned from the first `Send`/`SendJSON`/`SendData` call (not as a `nil` return).
 
 ## Static files
 

--- a/workshop/documentation/docs/gopernicus/topics/auth.md
+++ b/workshop/documentation/docs/gopernicus/topics/auth.md
@@ -22,7 +22,7 @@ It supports multiple credential types simultaneously:
 
 The bridge layer exposes these as HTTP endpoints with dual-client support — cookies for web, JSON tokens for mobile/API.
 
-**Key design choice:** Authentication emits events (`VerificationCodeRequested`, `PasswordResetRequested`) instead of sending emails directly. The bridge layer subscribes to these events and handles delivery. This keeps the core free of transport concerns.
+**Key design choice:** Authentication emits events (`VerificationCodeRequestedEvent`, `PasswordResetRequestedEvent`) instead of sending emails directly. The bridge layer subscribes to these events and handles delivery. This keeps the core free of transport concerns.
 
 → [Core — Authentication](../core/auth/authentication.md) · [Bridge — Authentication](../bridge/auth/authentication.md)
 
@@ -91,7 +91,7 @@ Invitations are generic over resource type — the same system handles org invit
 
 ## How they wire together
 
-In `app/server.go`, the composition root connects these pieces:
+In `app/server/main.go` (with config in `app/server/config/server.go`), the composition root connects these pieces:
 
 ```
 Authenticator ← repos, hasher, signer, bus, config

--- a/workshop/documentation/docs/gopernicus/topics/code-generation/overview.md
+++ b/workshop/documentation/docs/gopernicus/topics/code-generation/overview.md
@@ -16,7 +16,7 @@ The generator consumes four things:
 | Input | Location | Created by |
 |---|---|---|
 | `queries.sql` | `core/repositories/{domain}/{entity}/` | `gopernicus new repo` or by hand |
-| `bridge.yml` | `bridge/repositories/{domain}bridge/{entity}bridge/` | `gopernicus new repo` or by hand |
+| `bridge.yml` | `bridge/repositories/{domain}reposbridge/{entity}bridge/` | `gopernicus new repo` or by hand |
 | Reflected schema | `workshop/migrations/{db}/_public.json` | `gopernicus db reflect` |
 | Project manifest | `gopernicus.yml` | `gopernicus init` |
 
@@ -86,7 +86,7 @@ The generator also produces composites that wire all entities in a domain togeth
 | `core/repositories/{domain}/generated_composite.go` | Core | Aggregates all repos into a `Repositories` struct |
 | `bridge/repositories/{domain}bridge/generated_composite.go` | Bridge | Aggregates all bridges, exposes `AddHttpRoutes` |
 | `workshop/testing/fixtures/generated.go` | Testing | Factory functions for test data |
-| `workshop/testing/e2e/{entity}_generated_test.go` | Testing | HTTP-level CRUD tests |
+| `bridge/repositories/{domain}reposbridge/{entity}bridge/generated_e2e_test.go` | Bridge | HTTP-level CRUD tests (colocated with the bridge entity) |
 
 ## The pipeline
 

--- a/workshop/documentation/docs/gopernicus/topics/code-generation/schema-conventions.md
+++ b/workshop/documentation/docs/gopernicus/topics/code-generation/schema-conventions.md
@@ -30,7 +30,7 @@ Example scaffolded output for a `questions` table with `tenant_id`:
 
 ```sql
 -- @func: List
--- @filter:conditions *,-record_state
+-- @filter:conditions *
 SELECT * FROM questions
 WHERE tenant_id = @tenant_id AND $conditions AND $search
 ORDER BY $order LIMIT $limit;
@@ -74,8 +74,10 @@ A column named `record_state` generates `SoftDelete`, `Archive`, and `Restore` q
 
 The scaffolder also:
 
-- Excludes `record_state` from `@filter` specs (using `*,-record_state`)
+- Excludes `record_state` from `@search` specs (it's never a search column)
 - Excludes `record_state` from `@fields` on update
+
+The scaffolded `@filter` spec stays plain `*` — `record_state`'s active-default behavior is applied at generation time (see [`record_state` in filters](#record_state-in-filters)), not via a scaffolded `*,-record_state` filter.
 
 ---
 

--- a/workshop/documentation/docs/gopernicus/topics/extending-generated-code.md
+++ b/workshop/documentation/docs/gopernicus/topics/extending-generated-code.md
@@ -176,11 +176,9 @@ The `fop.go` bootstrap file controls default ordering, direction, and page size:
 ```go
 // core/repositories/tenancy/tenants/fop.go
 
-var (
-    DefaultOrderBy  = OrderByCreatedAt
-    DefaultDirection = fop.DESC
-    DefaultLimit     = 25
-)
+const DefaultOrderBy = OrderByCreatedAt
+const DefaultOrderDirection = fop.DESC
+const DefaultLimit = 25
 ```
 
 Change these to match your domain's natural ordering. The generated list handlers use these defaults when the caller doesn't specify.

--- a/workshop/documentation/docs/gopernicus/workshop/dev.md
+++ b/workshop/documentation/docs/gopernicus/workshop/dev.md
@@ -12,14 +12,14 @@ title: Dev
 Bring up local services:
 
 ```bash
-make dev-up
+make dev-data-up
 # or: docker compose -f workshop/dev/local-data-compose.yml up -d
 ```
 
 Tear them down:
 
 ```bash
-make dev-down
+make dev-data-down
 ```
 
 Data is persisted in `workshop/dev/data/` (gitignored) so volumes survive restarts.

--- a/workshop/documentation/docs/gopernicus/workshop/makefile.md
+++ b/workshop/documentation/docs/gopernicus/workshop/makefile.md
@@ -77,7 +77,7 @@ go tool gopernicus new case <name>            # scaffold a use case
 |---|---|
 | `make test` | Run unit tests (`go test ./...`). |
 | `make test-integration` | Run integration tests with `-tags=integration`. Requires a running database. |
-| `make test-e2e` | Run end-to-end tests with `-tags=e2e` against `workshop/testing/e2e/`. Requires a running server. |
+| `make test-e2e` | Run end-to-end tests with `-tags=e2e` (`go test -tags=e2e ./...`). Requires a running server. |
 
 ### Typical test workflow
 

--- a/workshop/documentation/docs/gopernicus/workshop/migrations.md
+++ b/workshop/documentation/docs/gopernicus/workshop/migrations.md
@@ -11,7 +11,7 @@ Migrations are **forward-only**. There are no down migrations.
 
 ## Databases & `gopernicus.yml`
 
-Gopernicus supports multiple named databases, each defined under the `databases` key in `gopernicus.yml`. The `primary` database is where Gopernicus-managed features (authentication, authorization, tenancy, events) store their data. You can define additional named databases for your own domain needs.
+Gopernicus supports multiple named databases, each defined under the `databases` key in `gopernicus.yml`. The `primary` database is where Gopernicus-managed features (authentication/authorization via `auth` and `rebac`, `tenancy`, `events`, and `jobs`) store their data. You can define additional named databases for your own domain needs.
 
 ```yaml
 databases:
@@ -20,8 +20,10 @@ databases:
     url_env_var: PRIMARY_POSTGRES_URL
     domains:
       auth: [principals, users, sessions, ...]
+      rebac: [rebac_relationships, groups, invitations, ...]
       tenancy: [tenants]
       events: [event_outbox]
+      jobs: [job_queue, job_schedules]
   analytics:
     driver: postgres/pgx
     url_env_var: ANALYTICS_POSTGRES_URL
@@ -38,10 +40,10 @@ When you add a new entity, you need to:
 1. Add the table in a migration file
 2. Declare it under the appropriate domain (or a new one) in `gopernicus.yml`
 
-Without the `gopernicus.yml` entry, the table won't be included in reflection or code generation.
+Without the `gopernicus.yml` entry, the table is still captured in reflection (`_public.json`), but it won't be scaffolded by `boot repos` or included in code generation.
 
 :::note Dialect support
-Gopernicus currently supports PostgreSQL (`postgres/pgx`) only. Support for other SQL dialects and bring-your-own migrator integrations are on the long-term roadmap but not yet planned.
+Gopernicus supports two database drivers: `postgres` (the default; the legacy spelling `postgres/pgx` normalizes to it) and `sqlite`. For `sqlite`, the `url_env_var` holds the database file path rather than a connection URL. Bring-your-own migrator integrations are on the long-term roadmap but not yet planned.
 :::
 
 ## Structure
@@ -80,7 +82,7 @@ gopernicus generate
 
 After reflecting, make sure the new table is declared under a domain in `gopernicus.yml`. Without it, `boot repos` and `gopernicus generate` won't include the table.
 
-`boot repos` creates `core/repositories/<domain>/<table>/queries.sql` for every unmapped table — existing files are never overwritten. Edit `queries.sql` to define operations and `bridge.yml` to configure HTTP routes before running `gopernicus generate`.
+`boot repos` creates `core/repositories/<domain>/<table>/queries.sql` for every domain-mapped table that lacks a repo (tables not mapped to any domain are ignored, framework spec-shipped feature entities are skipped, and existing files are never overwritten). Edit `queries.sql` to define operations and `bridge.yml` to configure HTTP routes before running `gopernicus generate`.
 
 :::tip Full walkthrough
 For a complete end-to-end example see [Adding a New Entity](../../guides/adding-new-entity.md).

--- a/workshop/documentation/docs/gopernicus/workshop/overview.md
+++ b/workshop/documentation/docs/gopernicus/workshop/overview.md
@@ -13,7 +13,7 @@ The Workshop is everything your project needs to run, but nothing that gets depl
 workshop/
 ├── migrations/         # SQL migration files and reflected schema
 ├── dev/                # Local development environment
-├── docker/             # Docker Compose services and related config
+├── docker/             # Dockerfiles for deploying your application
 ├── documentation/      # Your application's documentation
 └── testing/            # Test infrastructure, fixtures, and E2E setup
 ```
@@ -35,5 +35,5 @@ Gopernicus consolidates development concerns into `workshop/` for a few reasons:
 |---|---|
 | [Migrations](./migrations.md) | SQL migration files, schema reflection |
 | [Dev](./dev.md) | Local development environment setup |
-| [Docker](./docker.md) | Docker Compose services (PostgreSQL, Redis, Jaeger) |
+| [Docker](./docker.md) | Dockerfiles for deploying your application |
 | [Documentation](./documentation.md) | Your application's documentation |

--- a/workshop/documentation/docs/gopernicus/workshop/testing.md
+++ b/workshop/documentation/docs/gopernicus/workshop/testing.md
@@ -41,10 +41,14 @@ workshop/testing/
 ├── fixtures/         # Generated + custom fixture factories
 │   ├── generated.go  # Auto-generated per entity (regenerated)
 │   └── fixtures.go   # Custom helpers (created once, never overwritten)
-└── e2e/              # Generated E2E test files + setup bootstrap
-    ├── setup_test.go           # Bootstrap — implement once (never overwritten)
-    └── *_generated_test.go     # Route tests per entity (regenerated)
+├── testauth/         # Authenticator + signer helpers for E2E auth
+└── testsqlite/       # SQLite test database (spec-mode stores)
 ```
+
+E2E tests are not collected under `workshop/testing/`. The generator emits them per bridged entity, under `bridge/repositories/<domain>reposbridge/<entity>bridge/`:
+
+- `e2e_test.go` — bootstrap, created once (never overwritten), defines `migrateE2EDB`
+- `generated_e2e_test.go` — route tests + the `setupE2EServer` helper, regenerated
 
 ## testenv — composite environment
 
@@ -287,16 +291,15 @@ The fixture generator reads the reflected schema to pick sensible defaults so ge
 - **`json` / `jsonb` columns** (Go type `json.RawMessage`): defaults to `json.RawMessage("{}")` because Postgres rejects empty bytes as invalid JSON.
 - **Principal inheritance** (when an entity's PK is a FK to `principals`): the `principal_type` is set to the singular form of the table name (e.g. `service_accounts` → `service_account`) to match the canonical CHECK on the `principals` table.
 
-### E2E tests (`e2e/*_generated_test.go`)
+### E2E tests (`<entity>bridge/generated_e2e_test.go`)
 
-Each bridged entity gets HTTP-level tests for its CRUD routes:
+Each bridged entity gets HTTP-level tests for its CRUD routes, generated alongside the bridge package under `bridge/repositories/<domain>reposbridge/<entity>bridge/`:
 
 ```go
 //go:build e2e
 
-func TestGeneratedUser_Get(t *testing.T) {
-    ctx, db, ts := setupTestServer(t)
-    client := testhttp.New(ts.URL())
+func TestE2EUserCreateAndGet(t *testing.T) {
+    client, db := setupE2EServer(t)
 
     created := fixtures.CreateTestUserWithDefaults(t, ctx, db)
 
@@ -306,7 +309,7 @@ func TestGeneratedUser_Get(t *testing.T) {
 }
 ```
 
-The `setupTestServer` function is defined in `e2e/setup_test.go` — a bootstrap file you implement once to wire your full application.
+The `setupE2EServer(t) (*testhttp.Client, e2eDB)` helper is generated into `generated_e2e_test.go`. It calls `migrateE2EDB`, defined in the `e2e_test.go` bootstrap file you implement once to apply your project's migrations.
 
 ## Bootstrap vs regenerated files
 
@@ -314,7 +317,7 @@ The `setupTestServer` function is defined in `e2e/setup_test.go` — a bootstrap
 |---|---|---|
 | Fixtures | `fixtures/fixtures.go` | `fixtures/generated.go` |
 | Integration | `*pgx/store_test.go` | `*pgx/generated_test.go` |
-| E2E | `e2e/setup_test.go` | `e2e/*_generated_test.go` |
+| E2E | `<entity>bridge/e2e_test.go` | `<entity>bridge/generated_e2e_test.go` |
 
 Bootstrap files are created by the generator the first time, then never overwritten. Add your custom test helpers and scenario-specific tests in these files.
 

--- a/workshop/documentation/docs/gopernicus/zero-to-api.md
+++ b/workshop/documentation/docs/gopernicus/zero-to-api.md
@@ -54,7 +54,7 @@ to match your `.env` — no manual setup needed.
 gopernicus doctor
 ```
 
-All five checks should pass. If any fail, the output explains how to fix them.
+All checks should pass. If any fail, the output explains how to fix them.
 
 ## 4. Run Initial Migrations
 
@@ -76,17 +76,21 @@ gopernicus db reflect
 This writes `workshop/migrations/primary/_public.json` (consumed by the
 generator) and `_public.sql` (human-readable summary).
 
-## 6. Bootstrap Feature Repositories
+## 6. Bootstrap Project Repositories
 
-The framework features selected during init have their tables mapped in
-`gopernicus.yml`. Scaffold repositories for all of them at once:
+`gopernicus boot repos` scaffolds `queries.sql` and `bridge.yml` files for
+every project-owned table mapped to a domain in `gopernicus.yml`:
 
 ```bash
 gopernicus boot repos
 ```
 
-This creates `queries.sql` and `bridge.yml` files for every framework table
-(auth, rebac, tenancy, etc.).
+Framework feature entities (auth, rebac, tenancy, events, jobs) are spec-shipped
+with the framework and are intentionally skipped — their `queries.sql` ship
+version-locked with the framework, and you only create a local `queries.sql` by
+hand to eject a shipped spec. Right after init the only mapped domains are these
+framework domains, so this step does nothing until you map a project table of
+your own (see step 9).
 
 ## 7. Generate Code
 
@@ -108,12 +112,13 @@ This starts the server with [air](https://github.com/air-verse/air) for hot
 reload. You should see the boot sequence log:
 
 ```
-→ telemetry initialized
-→ database connected
-→ redis connected
-→ event bus started
-→ cache initialized
-→ server listening on 0.0.0.0:3000
+init service=telemetry
+init service=postgres
+init service=redis
+init service=event_bus
+init service=cache
+init service=http_server host=0.0.0.0:3000
+startup status="api router started" host=0.0.0.0:3000
 ```
 
 Verify it's running:
@@ -238,7 +243,7 @@ make dev-up                    # start postgres + redis
 gopernicus doctor              # verify health
 gopernicus db migrate          # apply migrations
 gopernicus db reflect          # snapshot schema
-gopernicus boot repos          # scaffold framework repos
+gopernicus boot repos          # scaffold project repos (framework specs skipped)
 gopernicus generate            # generate Go code
 make dev                       # run server with hot reload
 

--- a/workshop/documentation/docs/guides/adding-adapter.md
+++ b/workshop/documentation/docs/guides/adding-adapter.md
@@ -143,6 +143,13 @@ TWILIO_FROM_PHONE=+15551234567
 
 The project loads `.env` automatically based on the `env_file` field in `gopernicus.yml`.
 
+There are two patterns for populating a Config:
+
+- **`env:"..."` struct tags** decoded automatically from the environment (used by `goredisbus`, `postgres`, `redis`, `cryptids`). The Twilio example above uses this style.
+- **A plain Config struct populated explicitly at the call site** via `env.MustGet()` or `os.Getenv()` during wiring (used by the actual `sendgridemailer`, whose `Config` has no env tags). See Step 5.
+
+Pick one — don't mix struct-tag decoding with manual reads of the same variables.
+
 ---
 
 ## Step 4: Create a Development Stub (recommended)
@@ -274,7 +281,7 @@ infrastructure/
 This follows the established pattern seen in:
 - `cache/` with `memorycache/`, `rediscache/`, `noopcache/`
 - `storage/` with `diskstorage/`, `s3/`, `gcs/`
-- `events/` with `memorybus/`, `goredisbus/`, `outbox/`
+- `events/` with `memorybus/`, `goredisbus/`, `poller/`
 - `emailer/` with `sendgridemailer/`, `stdoutemailer/`
 
 ---

--- a/workshop/documentation/docs/guides/adding-auth-to-entity.md
+++ b/workshop/documentation/docs/guides/adding-auth-to-entity.md
@@ -39,7 +39,7 @@ Open the bridge package's `bridge.yml` file. Add `auth_relations` that describe 
 
 **Tenant-scoped entity** (has a `tenant_id` FK):
 
-When you scaffold with `gopernicus new repo`, the generator detects the `tenant_id` FK and produces these automatically in `bridge.yml`:
+When you scaffold with `gopernicus new repo`, the generator emits a relation for the *nearest parent* (a non-tenant parent FK takes precedence over `tenant_id`) plus `owner`. For a purely tenant-scoped entity, the nearest parent is the tenant relation, so it produces these automatically in `bridge.yml` (the relation name is derived from ancestry detection, not hardcoded):
 
 ```yaml
 auth_relations:
@@ -95,7 +95,7 @@ In `read(owner|manager|tenant->read)`:
 - `manager` -- direct: the caller has the `manager` relation on this resource
 - `tenant->read` -- inherited: the caller has `read` permission on the parent `tenant` resource
 
-The special relation `authenticated` means any authenticated caller (no specific relationship required).
+A bare relation name compiles to `Direct(name)` and only grants access when an explicit relationship tuple for that relation exists; there is no special "any authenticated caller" relation.
 
 ---
 
@@ -114,15 +114,20 @@ routes:
     path: /tenants/{tenant_id}/projects
     middleware:
       - authenticate
-      - authorize: prefilter(tenant:tenant_id, read)
+      - authorize:
+          pattern: prefilter
+          permission: read
+          subject: "tenant:tenant_id"
 ```
 
-The `tenant:tenant_id` syntax tells the prefilter to scope the check to the tenant specified by the `tenant_id` path parameter. For non-tenant-scoped entities, omit the scope:
+The `subject: "tenant:tenant_id"` field tells the prefilter to scope the check to the tenant specified by the `tenant_id` path parameter. For non-tenant-scoped entities, omit the `subject`:
 
 ```yaml
     middleware:
       - authenticate
-      - authorize: prefilter(read)
+      - authorize:
+          pattern: prefilter
+          permission: read
 ```
 
 ### check (for single-resource operations)
@@ -136,7 +141,9 @@ routes:
     path: /tenants/{tenant_id}/projects/{project_id}
     middleware:
       - authenticate
-      - authorize: check(read)
+      - authorize:
+          permission: read
+          param: project_id
 ```
 
 ### postfilter (for queries returning multiple results)
@@ -145,7 +152,9 @@ Postfilter runs the query first, then filters results based on authorization. Us
 
 ```yaml
     middleware:
-      - authorize: postfilter(read)
+      - authorize:
+          pattern: postfilter
+          permission: read
 ```
 
 Prefer `prefilter` over `postfilter` when possible -- it is more efficient because the database only returns authorized rows.
@@ -163,7 +172,9 @@ routes:
     path: /tenants/{tenant_id}/projects
     middleware:
       - authenticate
-      - authorize: check(create)
+      - authorize:
+          permission: create
+          param: tenant_id
     auth_create:
       - project:{project_id}#owner@{=subject}
       - project:{project_id}#tenant@tenant:{tenant_id}
@@ -267,13 +278,13 @@ func TestProjectAuthorization(t *testing.T) {
 |---|---|---|
 | `auth_relations` | `bridge.yml` | Define relations on the resource |
 | `auth_permissions` | `bridge.yml` | Define permissions from relations |
-| `authorize: prefilter(perm)` | Route middleware in `bridge.yml` | Filter list by authorized resources |
-| `authorize: prefilter(scope:param, perm)` | Route middleware in `bridge.yml` | Scoped prefilter (tenant) |
-| `authorize: check(perm)` | Route middleware in `bridge.yml` | Check permission on resource by ID |
-| `authorize: postfilter(perm)` | Route middleware in `bridge.yml` | Filter results after execution |
+| `authorize:` with `pattern: prefilter`, `permission: <perm>` | Route middleware in `bridge.yml` | Filter list by authorized resources |
+| `authorize:` with `pattern: prefilter`, `permission: <perm>`, `subject: "<rel>:<param>"` | Route middleware in `bridge.yml` | Scoped prefilter (tenant) |
+| `authorize:` with `permission: <perm>`, `param: <param>` | Route middleware in `bridge.yml` | Check permission on resource by ID (default pattern) |
+| `authorize:` with `pattern: postfilter`, `permission: <perm>` | Route middleware in `bridge.yml` | Filter results after execution |
 | `auth_create` | Route config in `bridge.yml` | Write relationship tuples on create |
 | `authenticate` | Route middleware in `bridge.yml` | Require authentication |
-| `with_permissions` | Route middleware in `bridge.yml` | Include caller's permissions in response |
+| `with_permissions` | Route field in `bridge.yml` | Include caller's permissions in response |
 
 ---
 

--- a/workshop/documentation/docs/guides/adding-new-entity.md
+++ b/workshop/documentation/docs/guides/adding-new-entity.md
@@ -104,7 +104,7 @@ The CLI looks up `projects` in `_public.json`, detects the `tenant_id` FK to `te
 - `SoftDelete`, `Archive`, `Restore` -- if the table has a `record_state` column
 - `Delete` -- hard delete
 
-The scaffold also generates `bridge.yml` in the bridge package directory with route definitions, ordered middleware arrays (authenticate, authorize, rate_limit), and auth schema (`auth_relations`, `auth_permissions`). Because the table has a `tenant_id` FK to `tenants`, the scaffold automatically:
+The scaffold also generates `bridge.yml` in the bridge package directory with route definitions, ordered middleware arrays (authenticate, rate_limit, authorize -- `rate_limit` comes before `authorize`, and `max_body_size` is prepended on mutations), and auth schema (`auth_relations`, `auth_permissions`). Because the table has a `tenant_id` FK to `tenants`, the scaffold automatically:
 - Nests routes under `/tenants/{tenant_id}/projects` in `bridge.yml`
 - Adds `tenant_id = @tenant_id AND` to WHERE clauses in `queries.sql`
 - Generates `auth_relations` and `auth_permissions` that inherit from the tenant
@@ -146,26 +146,33 @@ middleware, and auth schema:
 
 ```yaml
 routes:
-  list:
-    method: GET
+  - func: List
     path: /tenants/{tenant_id}/projects
     middleware:
-      - authenticate
+      - authenticate: any
       - rate_limit
-      - authorize: prefilter(tenant:tenant_id, read)
-  get:
-    method: GET
+      - authorize:
+          pattern: prefilter
+          permission: read
+          subject: "tenant:tenant_id"
+  - func: Get
     path: /tenants/{tenant_id}/projects/{project_id}
+    with_permissions: true
     middleware:
-      - authenticate
-      - authorize: check(read)
-      - with_permissions
-  create:
+      - authenticate: any
+      - rate_limit
+      - authorize:
+          permission: read
+          param: project_id
+  - func: Create
     method: POST
     path: /tenants/{tenant_id}/projects
     middleware:
-      - authenticate
-      - authorize: check(create)
+      - authenticate: any
+      - rate_limit
+      - authorize:
+          permission: create
+          param: tenant_id
 
 auth_relations:
   - tenant(tenant)
@@ -185,7 +192,7 @@ Common customizations:
 - **Add `unique_to_id`** middleware for slug-based lookups
 - **Add `max_body_size`** middleware for upload routes
 - **Adjust `auth_relations`** and `auth_permissions`
-- **Add `with_permissions`** to routes that should return caller's permissions
+- **Add the route-level key `with_permissions: true`** to routes that should return the caller's permissions (it is a per-route field, not a middleware entry)
 
 ---
 

--- a/workshop/documentation/docs/guides/adding-use-case.md
+++ b/workshop/documentation/docs/guides/adding-use-case.md
@@ -213,21 +213,23 @@ func (b *Bridge) AddHttpRoutes(group *web.RouteGroup) {
 Implement the handler method on Bridge. It decodes the request, calls the case, and encodes the response:
 
 ```go
-func (b *Bridge) httpArchiveProject(ctx web.Context) error {
-    var req ArchiveProjectRequest
-    if err := ctx.DecodeJSON(&req); err != nil {
-        return err
+func (b *Bridge) httpArchiveProject(w http.ResponseWriter, r *http.Request) {
+    req, err := web.DecodeJSON[ArchiveProjectRequest](r)
+    if err != nil {
+        web.RespondJSONError(w, web.ErrValidation(err))
+        return
     }
 
-    result, err := b.useCase.ArchiveProject(ctx.Request().Context(), projectadmin.ArchiveProjectInput{
+    result, err := b.useCase.ArchiveProject(r.Context(), projectadmin.ArchiveProjectInput{
         ProjectID: req.ProjectID,
         Reason:    req.Reason,
     })
     if err != nil {
-        return err
+        web.RespondJSONDomainError(w, err)
+        return
     }
 
-    return ctx.JSON(http.StatusOK, ArchiveProjectResponse{
+    web.RespondJSON(w, http.StatusOK, ArchiveProjectResponse{
         ProjectID: result.Project.ProjectID,
     })
 }

--- a/workshop/documentation/docs/roadmap/roadmap.md
+++ b/workshop/documentation/docs/roadmap/roadmap.md
@@ -53,10 +53,6 @@ This page is a work in progress. Items are unordered and unprioritized.
 
 - Multi-protocol support — bridge packages currently only generate HTTP handlers (`generated.go`). Future protocols (gRPC, GraphQL) would live alongside as `grpc.go`, `graphql.go`, etc., sharing the same `bridge.yml` configuration and core wiring
 
-## Project Structure
-
-- Move `core/testing/` (fixtures, setup helpers) into `workshop/testing/` — test infrastructure is a development concern, not part of the deployed binary, and belongs alongside migrations and dev tooling
-
 ## Packaging & Module Boundaries
 
 :::note
@@ -97,11 +93,8 @@ This is a **consideration**, not a committed direction. It captures a question w
 
 ## Testing
 
-- **Bridge auth handler tests + response shape contracts** *(elevated priority)* — `bridge/auth/authentication/` has no `*_test.go` files. Two related gaps that should be closed together since they share the same harness:
-  1. **Handler behavior tests.** The handlers (verify-email, change-password, remove-password send/verify, unlink-OAuth send/verify, OAuth link/unlink, etc.) all interact with the authenticator and the `httpErrFor` mapper, but there is no end-to-end test that exercises the full HTTP request → handler → core → response cycle. Bootstrapping requires a fake `Bridge` with stub repos + a real authenticator instance + an `httptest.Server`.
-  2. **Response shape contract tests.** Several response types now carry stability contracts in their doc comments (`OAuthAccountResponse`, `LoginResponse`, `MeResponse`, `OAuthCallbackResponse`, `UserResponse`, `SessionResponse`, `TokenResponse`, `SuccessResponse`). The Go type system catches Go-side renames, but it does *not* catch JSON tag changes (e.g. `json:"provider"` → `json:"provider_name"` while leaving the Go field as `Provider`) or accidental array-vs-envelope changes. Each documented contract should be backed by a golden-file marshaling test that fixtures a populated struct and asserts the exact JSON output. Treat the test failure as the breaking-change alarm — frontends bind directly to these shapes.
-  
-  Both items share the same `bridge/auth/authentication/*_test.go` bootstrap, so do them in one pass.
+- **Bridge auth response shape contract tests** *(elevated priority)* — `bridge/auth/authentication/` now has `*_test.go` coverage (`bridge_test.go`, `oauth_test.go`, `validation_test.go`), including handler behavior tests and a golden-file marshaling test for `OAuthAccountResponse`. The remaining gap is extending golden-file contract coverage to the other documented response types:
+  - **Response shape contract tests.** Several response types carry stability contracts in their doc comments (`LoginResponse`, `MeResponse`, `OAuthCallbackResponse`, `UserResponse`, `SessionResponse`, `TokenResponse`, `SuccessResponse`) that do not yet have golden-file tests. The Go type system catches Go-side renames, but it does *not* catch JSON tag changes (e.g. `json:"provider"` → `json:"provider_name"` while leaving the Go field as `Provider`) or accidental array-vs-envelope changes. Each documented contract should be backed by a golden-file marshaling test that fixtures a populated struct and asserts the exact JSON output. Treat the test failure as the breaking-change alarm — frontends bind directly to these shapes.
 - **Promote `penetration_test.go` harness to a shared `testing.go` helper** — the mocks and `testHarness` in `core/auth/authentication/penetration_test.go` are useful well beyond the penetration tests (they're already used by `sensitive_test.go`). Extracting them into a non-build-tagged helper would let other test files in the package use them without sharing the `penetration` build tag. This becomes more valuable once the bridge tests above exist, since the bridge tests will want to drive a real `Authenticator` and the cleanest way to construct one for tests is the existing harness.
 
 ## Enum filter values 500 on Postgres (robustness)


### PR DESCRIPTION
## Summary

Corrects **74 stale claims** across the cli and framework reference docs, surfaced by an automated docs-vs-code audit (and re-verified against framework source before applying). Doc-only changes — no code touched. 34 files, +199/−173.

## Notable fixes

- **generate.md** — generation is manifest-driven (`databases.<name>.domains`), not directory-scanning; `MustFindRoot` locates `go.mod`; E2E tests emit into the entity bridge dir (`generated_e2e_test.go` / `e2e_test.go`); cache files always emitted per entity.
- **init.md** — there is no interactive TUI (`init` is flag-driven); `gopernicus_version` is always written; satisfiers are *generated* not copied; auth bridges are *imported*; added `0006_job_schedules.sql`, `jobs -> job_schedules`, Telemetry default.
- **boot.md / new.md** — repo dirs use the package-normalized table name; corrected the scaffolder's real annotation set; slug-awareness emits `GetBySlug`/`GetIDBySlug` (no auto `unique_to_id`).
- **app/overview.md + bridge/auth/authentication.md** — `NewSubscribers(emailer, log)` signature; the origin matcher is `allowlist.Matcher` from `bridge/transit/allowlist`.
- **emailer.md** — `Emailer` implements `Renderer` (there is no `notify.Notifier` package).
- **middleware / repositories** — `authenticate` accepts `user|service_account|user_session|any`; `GetRelationship` returns `(RelationshipInfo, bool)`.
- **design-philosophy / core / overview** — document the framework-provided `core/jobs` and `bridge/events` packages.

## Out of scope (follow-ups)

The audit also surfaced three framework **code** issues, intentionally not addressed here:
1. Generated `server.New()` (`app_tmpl.go`) doesn't wire `authbridge`/`invitationsbridge` subscribers (only a comment).
2. `gopernicus new adapter token <name>` is documented but unsupported in `new_adapter`.
3. Stale `notify.Notifier` comments in `infrastructure/communications/emailer/emailer.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)